### PR TITLE
fix: section mismatch in reference warning 

### DIFF
--- a/kernel_compat.h
+++ b/kernel_compat.h
@@ -101,4 +101,3 @@ static inline void __init security_add_hooks_compat(struct security_hook_list *h
 #endif
 
 }
-


### PR DESCRIPTION
fix warnings when CONFIG_SECTION_MISMATCH_WARN_ONLY=n

```
WARNING: modpost: vmlinux.o: section mismatch in reference: security_add_hooks_compat (section: .text) -> security_add_hooks (section: .init.text)
ERROR: modpost: Section mismatches detected.
Set CONFIG_SECTION_MISMATCH_WARN_ONLY=y to allow them.
```

waiting for @Xiaomichael test