### PR TITLE
Adjust debug log output to default

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -35,16 +35,6 @@ config BBG_BLOCK_BOOT
           fastboot mode).
           If unsure, leave this n.
 
-config BBG_DEBUG
-       bool "Output Details to Log for Debugging"
-       depends on BBG
-       default y
-       help
-          Output details about rejected requests
-          (Rejected process name & domain) to dmesg
-          log for debugging.
-          If unsure, leave this y.
-
 config BBG_DOMAIN_PROTECTION
        bool "Interception for malicious Selinux domain switching"
        depends on BBG

--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,3 @@ endif
 $(info -- BBG was enabled!)
 $(info -- BBG version: $(COMMIT_SHA))
 ccflags-y += -DBBG_VERSION=$(COMMIT_SHA)
-
-

--- a/baseband_guard.c
+++ b/baseband_guard.c
@@ -16,12 +16,6 @@
 
 #define BB_ENFORCING 1
 
-#ifdef CONFIG_BBG_DEBUG
-#define BB_DEBUG 1
-#else
-#define BB_DEBUG 0
-#endif
-
 #if CONFIG_BBG_ANTI_SPOOF_DOMAIN == 1
 #define BB_ANTI_SPOOF_NO_TRUST_PERMISSIVE_ONCE 0
 #define BB_ANTI_SPOOF_DISABLE_PERMISSIVE 1
@@ -120,9 +114,7 @@ static void allow_add(dev_t dev)
 	if (!n) return;
 	n->dev = dev;
 	hash_add(allowed_devs, &n->h, (u64)dev);
-#if BB_DEBUG
 	bb_pr("allow-cache dev %u:%u\n", MAJOR(dev), MINOR(dev));
-#endif
 }
 
 static inline bool is_allowed_partition_dev_resolve(dev_t cur)
@@ -175,10 +167,8 @@ static bool is_zram_device(dev_t dev)
 	if (bdev->bd_disk) {
 		if (strncmp(bdev->bd_disk->disk_name, "zram", 4) == 0) {
 			is_zram = true;
-#if BB_DEBUG
 			bb_pr("zram dev %u:%u (%s) identified, whitelisting\n",
 				MAJOR(dev), MINOR(dev), bdev->bd_disk->disk_name);
-#endif
 		}
 	}
 
@@ -273,7 +263,6 @@ static void bbg_log_deny_detail(const char *why, struct file *file, unsigned int
 	if (cmdbuf)
 		bbg_get_cmdline(cmdbuf, CMD_BUFLEN);
 
-#if BB_DEBUG
 	if (cmd_opt) {
 		pr_info_ratelimited(
 			"baseband_guard: deny %s cmd=0x%x dev=%u:%u path=%s pid=%d comm=%s argv=\"%s\"\n",
@@ -287,19 +276,6 @@ static void bbg_log_deny_detail(const char *why, struct file *file, unsigned int
 			path ? path : "?", current->pid, current->comm,
 			cmdbuf ? cmdbuf : "?");
 	}
-#else
-	if (cmd_opt) {
-		pr_info_ratelimited(
-			"baseband_guard: deny %s cmd=0x%x dev=%u:%u path=%s pid=%d\n",
-			why, cmd_opt, MAJOR(dev), MINOR(dev),
-			path ? path : "?", current->pid);
-	} else {
-		pr_info_ratelimited(
-			"baseband_guard: deny %s dev=%u:%u path=%s pid=%d\n",
-			why, MAJOR(dev), MINOR(dev),
-			path ? path : "?", current->pid);
-	}
-#endif
 
 	kfree(cmdbuf);
 	kfree(pathbuf);


### PR DESCRIPTION
Output detailed rejected process name & domain to dmesg log by default, since people who read logs must need detailed log output (also preparing for new debug opinion design).