### PR TITLE
Fix Logic error and update code for max compatibility

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -78,6 +78,12 @@ jobs:
           remove-codeql: 'true'
           remove-docker-images: 'true'
 
+      - name: Download Apache Arrow's util_free_space.sh
+        run: |
+          curl -L -o util_free_space.sh https://raw.githubusercontent.com/apache/arrow/main/ci/scripts/util_free_space.sh
+          chmod +x util_free_space.sh
+          ./util_free_space.sh
+
       - name: Set CONFIG Environment Variable
         run: |
           # Set CONFIG dynamically based on matrix values

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 bbg-objs += baseband_guard.o
 bbg-objs += tracing/tracing.o
 
-ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
+ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include -I$(srctree)/block
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
 
 obj-$(CONFIG_BBG) += bbg.o

--- a/baseband_guard.c
+++ b/baseband_guard.c
@@ -96,11 +96,12 @@ static inline bool is_allowed_partition_dev_resolve(dev_t cur)
 	for (i = 0; i < allowlist_cnt; i++) {
 		const char *n = allowlist_names[i];
 		bool ok = false;
+		char *nm, *na, *nb;
 
 		if (resolve_byname_dev(n, &dev) && dev == cur) return true;
 
-		if (!ok && suf) {
-			char *nm = kasprintf(GFP_ATOMIC, "%s%s", n, suf);
+		if (suf) {
+			nm = kasprintf(GFP_ATOMIC, "%s%s", n, suf);
 			if (nm) {
 				ok = resolve_byname_dev(nm, &dev);
 				kfree(nm);
@@ -108,13 +109,14 @@ static inline bool is_allowed_partition_dev_resolve(dev_t cur)
 			}
 		}
 		if (!ok) {
-			char *na = kasprintf(GFP_ATOMIC, "%s_a", n);
-			char *nb = kasprintf(GFP_ATOMIC, "%s_b", n);
+			na = kasprintf(GFP_ATOMIC, "%s_a", n);
 			if (na) {
 				ok = resolve_byname_dev(na, &dev);
 				kfree(na);
-				if (ok && dev == cur) { if (nb) kfree(nb); return true; }
+				if (ok && dev == cur) return true;
 			}
+			
+			nb = kasprintf(GFP_ATOMIC, "%s_b", n);
 			if (nb) {
 				ok = resolve_byname_dev(nb, &dev);
 				kfree(nb);
@@ -233,7 +235,7 @@ static inline int is_protected_blkdev(struct dentry *dentry)
 {
     struct inode *inode;
 
-    if (!IS_ERR_OR_NULL(dentry))
+    if (IS_ERR_OR_NULL(dentry))
         return 0;
 
     inode = d_backing_inode(dentry);
@@ -253,7 +255,7 @@ static inline int is_protected_blkdev(struct dentry *dentry)
 	// there will handle all symlink, to avoid create an symlink -> /dev/block/by-name and modify
     if (unlikely(S_ISLNK(inode->i_mode) && inode->i_op->get_link)) { // fix /dev/block/by-name/xxx rename bypass
 		DEFINE_DELAYED_CALL(done);
-		const char* symlink_target_link = inode->i_op->get_link(dentry, inode, &done);
+		const char* symlink_target_link = vfs_get_link(dentry, &done);
 		int result = 0;
 		struct path target_path;
 
@@ -324,7 +326,7 @@ static int bb_inode_symlink(struct inode *dir, struct dentry *dentry, const char
 static int bb_inode_rename(struct inode *old_dir, struct dentry *old_dentry,
                            struct inode *new_dir, struct dentry *new_dentry)
 {
-    if (!old_dentry)
+    if (IS_ERR_OR_NULL(old_dentry))
         return 0;
 
     if (unlikely(is_protected_blkdev(old_dentry)))

--- a/kernel_compat.h
+++ b/kernel_compat.h
@@ -3,6 +3,7 @@
 #include <linux/lsm_hooks.h>
 #include <linux/version.h>
 #include "objsec.h"
+#include "blk.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 static __maybe_unused inline int lookup_bdev_compat(char *path, dev_t *out) {

--- a/tracing/tracing.c
+++ b/tracing/tracing.c
@@ -3,6 +3,13 @@
 #include <linux/errno.h>
 #include <linux/cred.h>
 
+int bb_cred_prepare(struct cred *new, const struct cred *old, gfp_t gfp);
+void bb_cred_transfer(struct cred *new, const struct cred *old);
+int bb_bprm_set_creds(struct linux_binprm *bprm);
+
+int __maybe_unused bbg_process_setpermissive(void);
+int __maybe_unused bbg_test_domain_transition(u32 target_secid);
+
 #ifdef BBG_USE_DEFINE_LSM
 struct lsm_blob_sizes bbg_blob_sizes __ro_after_init = {
 	.lbs_cred = sizeof(struct bbg_cred_security_struct),


### PR DESCRIPTION
1. Fix logic error caused by code conversion to handle multiple errors from `if (!dentry)` to `if (!IS_ERR_OR_NULL(dentry))`.

2. Use `vfs_get_link` instead of `inode->i_op->get_link` for maximum compatibility.

3. Minor logic changes in is_allowed_partition_dev_resolve.

4. Fix Compile errors for 6.14+ kernels.

5. Fix no space left errors for github runner.