### PR TITLE
refactor: 优化设备缓存机制并重构进程信任检测逻辑

### DIFF
--- a/baseband_guard.c
+++ b/baseband_guard.c
@@ -48,42 +48,140 @@ static bool inline resolve_byname_dev(const char *name, dev_t *out)
 	return true;
 }
 
-struct device_hash_node { dev_t dev; struct hlist_node h; };
-DEFINE_HASHTABLE(allowed_devs, 7);
+struct device_hash_node {
+	dev_t dev;
+	struct hlist_node h;
+	struct list_head lru;
+	struct rcu_head rcu;
+};
 
+static DEFINE_SPINLOCK(bbg_cache_lock);
+static LIST_HEAD(bbg_lru_list);
+static unsigned int bbg_cache_count;
+
+#define BBG_CACHE_MAX 256
+
+DEFINE_HASHTABLE(allowed_devs, 7);
 DEFINE_HASHTABLE(blocked_devs, 7);
+
+static void bbg_node_free_rcu(struct rcu_head *head)
+{
+	struct device_hash_node *node =
+		container_of(head, struct device_hash_node, rcu);
+	kfree(node);
+}
 
 static bool allow_has(dev_t dev)
 {
 	struct device_hash_node *p;
+	bool ret = false;
 
-	hash_for_each_possible(blocked_devs, p, h, (u64)dev) // process blocklist
-		if (p->dev == dev) return false;
+	rcu_read_lock();
+	hash_for_each_possible_rcu(blocked_devs, p, h, (u64)dev) {
+		if (p->dev == dev) {
+			ret = false;
+			goto out;
+		}
+	}
+	hash_for_each_possible_rcu(allowed_devs, p, h, (u64)dev) {
+		if (p->dev == dev) {
+			ret = true;
+			goto out;
+		}
+	}
+out:
+	rcu_read_unlock();
+	return ret;
+}
 
-	hash_for_each_possible(allowed_devs, p, h, (u64)dev)
-		if (p->dev == dev) return true;
-	return false;
+static void bbg_cache_shrink(void)
+{
+	struct device_hash_node *victim;
+
+	while (bbg_cache_count >= BBG_CACHE_MAX) {
+		victim = list_first_entry_or_null(&bbg_lru_list,
+						  struct device_hash_node, lru);
+		if (!victim)
+			break;
+
+		list_del(&victim->lru);
+		hlist_del_rcu(&victim->h);
+		bbg_cache_count--;
+		call_rcu(&victim->rcu, bbg_node_free_rcu);
+	}
 }
 
 static void allow_add(dev_t dev)
 {
 	struct device_hash_node *n;
-	if (!dev || allow_has(dev)) return;
+
+	spin_lock(&bbg_cache_lock);
+	if (!dev) {
+		spin_unlock(&bbg_cache_lock);
+		return;
+	}
+	hash_for_each_possible(allowed_devs, n, h, (u64)dev) {
+		if (n->dev == dev) {
+			spin_unlock(&bbg_cache_lock);
+			return;
+		}
+	}
+	hash_for_each_possible(blocked_devs, n, h, (u64)dev) {
+		if (n->dev == dev) {
+			spin_unlock(&bbg_cache_lock);
+			return;
+		}
+	}
+
+	bbg_cache_shrink();
+
 	n = kmalloc(sizeof(*n), GFP_ATOMIC);
-	if (!n) return;
+	if (!n) {
+		spin_unlock(&bbg_cache_lock);
+		return;
+	}
 	n->dev = dev;
-	hash_add(allowed_devs, &n->h, (u64)dev);
+	hash_add_rcu(allowed_devs, &n->h, (u64)dev);
+	list_add_tail(&n->lru, &bbg_lru_list);
+	bbg_cache_count++;
+	spin_unlock(&bbg_cache_lock);
 	bb_pr("allow-cache dev %u:%u\n", MAJOR(dev), MINOR(dev));
 }
 
 static void block_add(dev_t dev)
 {
 	struct device_hash_node *n;
-	if (!dev || allow_has(dev)) return;
+
+	spin_lock(&bbg_cache_lock);
+	if (!dev) {
+		spin_unlock(&bbg_cache_lock);
+		return;
+	}
+	hash_for_each_possible(allowed_devs, n, h, (u64)dev) {
+		if (n->dev == dev) {
+			spin_unlock(&bbg_cache_lock);
+			return;
+		}
+	}
+	hash_for_each_possible(blocked_devs, n, h, (u64)dev) {
+		if (n->dev == dev) {
+			spin_unlock(&bbg_cache_lock);
+			return;
+		}
+	}
+
+	bbg_cache_shrink();
+
 	n = kmalloc(sizeof(*n), GFP_ATOMIC);
-	if (!n) return;
+	if (!n) {
+		spin_unlock(&bbg_cache_lock);
+		return;
+	}
 	n->dev = dev;
-	hash_add(blocked_devs, &n->h, (u64)dev);
+	hash_add_rcu(blocked_devs, &n->h, (u64)dev);
+	list_add_tail(&n->lru, &bbg_lru_list);
+	bbg_cache_count++;
+	spin_unlock(&bbg_cache_lock);
 	bb_pr("block-cache dev %u:%u\n", MAJOR(dev), MINOR(dev));
 }
 
@@ -101,7 +199,7 @@ static inline bool is_allowed_partition_dev_resolve(dev_t cur)
 		if (resolve_byname_dev(n, &dev) && dev == cur) return true;
 
 		if (suf) {
-			nm = kasprintf(GFP_ATOMIC, "%s%s", n, suf);
+			nm = kasprintf(GFP_KERNEL, "%s%s", n, suf);
 			if (nm) {
 				ok = resolve_byname_dev(nm, &dev);
 				kfree(nm);
@@ -109,14 +207,14 @@ static inline bool is_allowed_partition_dev_resolve(dev_t cur)
 			}
 		}
 		if (!ok) {
-			na = kasprintf(GFP_ATOMIC, "%s_a", n);
+			na = kasprintf(GFP_KERNEL, "%s_a", n);
 			if (na) {
 				ok = resolve_byname_dev(na, &dev);
 				kfree(na);
 				if (ok && dev == cur) return true;
 			}
 			
-			nb = kasprintf(GFP_ATOMIC, "%s_b", n);
+			nb = kasprintf(GFP_KERNEL, "%s_b", n);
 			if (nb) {
 				ok = resolve_byname_dev(nb, &dev);
 				kfree(nb);
@@ -176,13 +274,16 @@ static void bbg_log_deny_detail(const char *why, struct file *file, struct inode
 {
 	const int PATH_BUFLEN = 256;
 	const int CMD_BUFLEN  = 256;
-
-	char *pathbuf = kmalloc(PATH_BUFLEN, GFP_ATOMIC);
-	char *cmdbuf  = kmalloc(CMD_BUFLEN,  GFP_ATOMIC);
-
-	const char *path = pathbuf ? bbg_file_path(file, pathbuf, PATH_BUFLEN) : NULL;
+	char *pathbuf = NULL;
+	char *cmdbuf  = NULL;
+	const char *path = NULL;
 	dev_t dev = inode ? inode->i_rdev : 0;
 
+	pathbuf = kmalloc(PATH_BUFLEN, GFP_ATOMIC);
+	if (pathbuf)
+		path = bbg_file_path(file, pathbuf, PATH_BUFLEN);
+
+	cmdbuf = kmalloc(CMD_BUFLEN, GFP_ATOMIC);
 	if (cmdbuf)
 		bbg_get_cmdline(cmdbuf, CMD_BUFLEN);
 

--- a/tracing/tracing.c
+++ b/tracing/tracing.c
@@ -40,9 +40,6 @@ void bb_cred_transfer(struct cred *new, const struct cred *old)
 
 int bb_bprm_set_creds(struct linux_binprm *bprm)
 {
-	static int su_sid = -1;
-	static int magisk_sid = -1;
-	static int ksu_sid = -1;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
 	struct task_security_struct *new_selinux_tsec;
 	const struct task_security_struct *old_selinux_tsec;
@@ -52,51 +49,41 @@ int bb_bprm_set_creds(struct linux_binprm *bprm)
 #endif
 	const struct bbg_cred_security_struct *old_bbg_tsec;
 	struct bbg_cred_security_struct *new_bbg_tsec;
+	const struct cred *new_cred = bprm->cred;
 
 	old_selinux_tsec = selinux_cred(current_cred());
-	new_selinux_tsec = selinux_cred(bprm->cred);
-	new_bbg_tsec = bbg_cred(bprm->cred);
+	new_selinux_tsec = selinux_cred(new_cred);
+	new_bbg_tsec = bbg_cred(new_cred);
 	old_bbg_tsec = bbg_cred(current_cred());
 
 	new_bbg_tsec->is_untrusted_process = old_bbg_tsec->is_untrusted_process;
 
-	if (new_bbg_tsec->is_untrusted_process) {
-		return 0; // already flag as untrusted_process, no need check current domain
-	}
+	if (new_bbg_tsec->is_untrusted_process)
+		return 0;
 
-	if (unlikely(!selinux_initialized_compat())) return 0; // we keep this only for module scripts, i don't want hook execve
+	if (unlikely(!selinux_initialized_compat()))
+		return 0;
 
-	if (su_sid == -1) { // root impl compatible
-		if (security_secctx_to_secid("u:r:su:s0", strlen("u:r:su:s0"), &su_sid)) {
-			su_sid = -EINVAL;
-		}
-	}
+	if (cap_raised(new_cred->cap_effective, CAP_SYS_ADMIN) ||
+	    cap_raised(new_cred->cap_effective, CAP_DAC_OVERRIDE) ||
+	    cap_raised(new_cred->cap_effective, CAP_DAC_READ_SEARCH)) {
+		const char *comm = current->comm;
+		
+		if (current->pid <= 2)
+			return 0;
+		
+		if (strcmp(comm, "init") == 0 ||
+		    strcmp(comm, "kthreadd") == 0 ||
+		    strcmp(comm, "ueventd") == 0 ||
+		    strcmp(comm, "logd") == 0 ||
+		    strcmp(comm, "servicemanager") == 0 ||
+		    strncmp(comm, "android.hardware", 16) == 0 ||
+		    strncmp(comm, "vendor.", 7) == 0)
+			return 0;
 
-	if (magisk_sid == -1) {
-		if (security_secctx_to_secid("u:r:magisk:s0", strlen("u:r:magisk:s0"), &magisk_sid) != 0) {
-			magisk_sid = -EINVAL;
-		}
-	}
-
-	if (ksu_sid == -1) {
-                if (security_secctx_to_secid("u:r:ksu:s0", strlen("u:r:ksu:s0"), &ksu_sid) != 0) {
-                        ksu_sid = -EINVAL;
-                }
-        }
-
-	if (unlikely(
-		old_selinux_tsec->sid == su_sid || old_selinux_tsec->osid == su_sid || // kernelsu old
-		new_selinux_tsec->sid == su_sid || new_selinux_tsec->osid == su_sid ||
-
-                old_selinux_tsec->sid == ksu_sid || old_selinux_tsec->osid == ksu_sid || // kernelsu new
-                new_selinux_tsec->sid == ksu_sid || new_selinux_tsec->osid == ksu_sid ||
-
-		old_selinux_tsec->sid == magisk_sid || old_selinux_tsec->osid == magisk_sid || // magisk/apatch
-		new_selinux_tsec->sid == magisk_sid || new_selinux_tsec->osid == magisk_sid
-	)) {
 		new_bbg_tsec->is_untrusted_process = 1;
-		pr_info("baseband_guard: pid %d has been marked as untrusted process due to its selinux domain\n",
-			current->pid);
+		pr_info("baseband_guard: pid %d comm=%s marked untrusted: gained privileged capabilities\n",
+			current->pid, current->comm);
 	}
 
 	return 0;


### PR DESCRIPTION
- baseband_guard.c:
  - 引入LRU 缓存淘汰策略和RCU 保护，替换原有的简单哈希表实现
  - 增加自旋锁以保障并发安全，限制缓存最大数量为 256
  - 修正内存分配标志，将部分GFP_ATOMIC改为 GFP_KERNEL以提高稳定性
  - 优化日志记录函数的内存分配与错误处理流程

- tracing/tracing.c:
  - 移除基于SELinux SID (su/magisk/ksu) 的硬编码检测逻辑
  - 改用检查特权能力位(CAP_SYS_ADMIN 等) 来标记不可信进程
  - 增加对系统关键进程(init, ueventd等)的白名单豁免
  - 简化bb_bprm_set_creds函数结构，提高代码可维护性