### PR TITLE
Add vendor_kernel_boot to allowlist and move vendor_boot to CONFIG_BBG_BLOCK_BOOT

### DIFF
--- a/baseband_guard.h
+++ b/baseband_guard.h
@@ -14,8 +14,9 @@
 static const char * const allowlist_names[] = {
 #ifndef CONFIG_BBG_BLOCK_BOOT
 	"boot", "init_boot",
+	"vendor_boot", "vendor_kernel_boot",
 #endif
-	"dtbo", "vendor_boot",
+	"dtbo",
 	"userdata", "cache", "metadata", "misc",
 	"vbmeta", "vbmeta_system", "vbmeta_vendor",
 #ifndef CONFIG_BBG_BLOCK_RECOVERY


### PR DESCRIPTION
In the Android boot architecture, vendor_kernel_boot is a dedicated partition introduced for newer devices (starting with Pixel 7 and later) to separate kernel-specific components from general vendor resources.

Before this change, the standard vendor_boot partition contained both general vendor ramdisk fragments and kernel-related artifacts. The vendor_kernel_boot partition was created to host these specific kernel artifacts independently, allowing for a cleaner separation of concerns during the boot process.