### PR TITLE
fix: harden disk API compatibility and block device mediation

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,7 +10,19 @@ on:
   pull_request:
 
 jobs:
+  host-tests:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run host tests
+        run: sh tests/run-tests.sh
+
   build-check:
+    needs: host-tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 bbg-objs += baseband_guard.o
 bbg-objs += tracing/tracing.o
 bbg-objs += blkdev_helper.o
+bbg-objs += partition_match.o
+bbg-objs += block_policy.o
 
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include -I$(srctree)/block
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
@@ -47,10 +49,11 @@ ifeq ($(shell grep -q "selinux_state" $(srctree)/security/selinux/include/securi
     $(info -- Baseband-guard/compat: found selinux_state)
 endif
 
-ifneq ($(shell grep -q "disk_get_part" $(srctree)/include/linux/genhd.h 2>/dev/null && echo true),true)
-    ccflags-y += -DBBG_COMPAT_HAS_BLOCK_DEVICE_API
-    $(info -- Baseband-guard/compat: found modern block device api)
-endif
+BBG_BLOCK_API_FLAGS := $(shell sh $(BBG_DIR)/scripts/detect-block-api.sh $(srctree))
+ccflags-y += $(BBG_BLOCK_API_FLAGS)
+
+BBG_LSM_API_FLAGS := $(shell sh $(BBG_DIR)/scripts/detect-lsm-api.sh $(srctree))
+ccflags-y += $(BBG_LSM_API_FLAGS)
 
 HAS_DEFINE_LSM := $(shell grep -q "\#define DEFINE_LSM(lsm)" $(srctree)/include/linux/lsm_hooks.h && echo true)
 

--- a/baseband_guard.c
+++ b/baseband_guard.c
@@ -11,58 +11,44 @@
 #include <linux/version.h>
 #include <linux/cred.h>
 #include <linux/dcache.h>
-#include <linux/hashtable.h>
+#include <linux/ratelimit.h>
+
+#if defined(BBG_HAS_URING_CMD) && defined(CONFIG_IO_URING)
+#if defined(BBG_URING_CMD_HEADER_CMD) && \
+	defined(BBG_URING_CMD_HEADER_LEGACY)
+#error "Baseband-guard: multiple io_uring command headers selected"
+#elif defined(BBG_URING_CMD_HEADER_CMD)
+#include <linux/io_uring/cmd.h>
+#elif defined(BBG_URING_CMD_HEADER_LEGACY)
+#include <linux/io_uring.h>
+#else
+#error "Baseband-guard: io_uring command header not selected"
+#endif
+#endif
 
 #include "kernel_compat.h"
 #include "baseband_guard.h"
 #include "tracing/tracing.h"
 #include "blkdev_helper.h"
+#include "block_policy.h"
 
-struct device_hash_node { dev_t dev; struct hlist_node h; };
-DEFINE_HASHTABLE(allowed_devs, 7);
-
-static bool allow_has(dev_t dev)
-{
-	struct device_hash_node *p;
-
-	hash_for_each_possible(allowed_devs, p, h, (u64)dev)
-		if (p->dev == dev) return true;
-	return false;
-}
-
-static void allow_add(dev_t dev)
-{
-	struct device_hash_node *n;
-	if (!dev || allow_has(dev)) return;
-	n = kmalloc(sizeof(*n), GFP_ATOMIC);
-	if (!n) return;
-	n->dev = dev;
-	hash_add(allowed_devs, &n->h, (u64)dev);
-	bb_pr("allow-cache dev %u:%u\n", MAJOR(dev), MINOR(dev));
-}
+static DEFINE_RATELIMIT_STATE(bbg_deny_rs, DEFAULT_RATELIMIT_INTERVAL,
+			      DEFAULT_RATELIMIT_BURST);
 
 static bool is_zram_device(dev_t dev)
 {
 	bool is_zram = bbg_is_named_device(dev, "zram");
 	if (is_zram) {
-		bb_pr("zram dev %u:%u identified, whitelisting\n",
+		bb_pr("zram dev %u:%u allowed for current access\n",
 				MAJOR(dev), MINOR(dev));
 	}
 	return is_zram;
 }
 
-static bool reverse_allow_match_and_cache(dev_t cur)
+static bool is_allowed_block_device(dev_t dev)
 {
-	if (!cur) return false;
-	if (is_zram_device(cur)) {
-		allow_add(cur);
-		return true;
-	}
-	if (is_allowed_partition_dev_resolve(cur)) {
-		allow_add(cur);
-		return true;
-	}
-	return false;
+	if (!dev) return false;
+	return is_zram_device(dev) || is_allowed_partition_dev_resolve(dev);
 }
 
 static const char *bbg_file_path(struct file *file, char *buf, int buflen)
@@ -78,6 +64,7 @@ static int bbg_get_cmdline(char *buf, int buflen)
 {
 	int n, i;
 	if (!buf || buflen <= 0) return 0;
+	buf[0] = '\0';
 	n = get_cmdline(current, buf, buflen);
 	if (n <= 0) return 0;
 	for (i = 0; i < n - 1; i++) if (buf[i] == '\0') buf[i] = ' ';
@@ -90,29 +77,25 @@ static void bbg_log_deny_detail(const char *why, struct file *file, struct inode
 {
 	const int PATH_BUFLEN = 256;
 	const int CMD_BUFLEN  = 256;
+	char *pathbuf;
+	char *cmdbuf;
+	const char *path;
+	const char *cmdline = NULL;
+	dev_t dev;
 
-	char *pathbuf = kmalloc(PATH_BUFLEN, GFP_ATOMIC);
-	char *cmdbuf  = kmalloc(CMD_BUFLEN,  GFP_ATOMIC);
+	pathbuf = kmalloc(PATH_BUFLEN, GFP_ATOMIC);
+	cmdbuf = kmalloc(CMD_BUFLEN, GFP_ATOMIC);
+	path = pathbuf ? bbg_file_path(file, pathbuf, PATH_BUFLEN) : NULL;
+	dev = inode ? inode->i_rdev : 0;
 
-	const char *path = pathbuf ? bbg_file_path(file, pathbuf, PATH_BUFLEN) : NULL;
-	dev_t dev = inode ? inode->i_rdev : 0;
+	if (cmdbuf && bbg_get_cmdline(cmdbuf, CMD_BUFLEN) > 0)
+		cmdline = cmdbuf;
 
-	if (cmdbuf)
-		bbg_get_cmdline(cmdbuf, CMD_BUFLEN);
-
-	if (cmd_opt) {
-		pr_info(
-			"baseband_guard: deny %s cmd=0x%x dev=%u:%u path=%s pid=%d comm=%s argv=\"%s\"\n",
-			why, cmd_opt, MAJOR(dev), MINOR(dev),
-			path ? path : "?", current->pid, current->comm,
-			cmdbuf ? cmdbuf : "?");
-	} else {
-		pr_info(
-			"baseband_guard: deny %s dev=%u:%u path=%s pid=%d comm=%s argv=\"%s\"\n",
-			why, MAJOR(dev), MINOR(dev),
-			path ? path : "?", current->pid, current->comm,
-			cmdbuf ? cmdbuf : "?");
-	}
+	pr_info(
+		"baseband_guard: deny %s cmd=0x%x dev=%u:%u path=%s pid=%d comm=%s argv=\"%s\"\n",
+		why, cmd_opt, MAJOR(dev), MINOR(dev),
+		path ? path : "?", current->pid, current->comm,
+		cmdline ? cmdline : "?");
 
 	kfree(cmdbuf);
 	kfree(pathbuf);
@@ -120,10 +103,49 @@ static void bbg_log_deny_detail(const char *why, struct file *file, struct inode
 
 static int deny(const char *why, struct file *file, struct inode *inode, unsigned int cmd_opt)
 {
-	bbg_log_deny_detail(why, file, inode, cmd_opt);
-	bb_pr_rl("deny %s pid=%d comm=%s\n", why, current->pid, current->comm);
+	if (__ratelimit(&bbg_deny_rs))
+		bbg_log_deny_detail(why, file, inode, cmd_opt);
 	if (!BB_ENFORCING) return 0;
 	return -EPERM;
+}
+
+#if defined(BBG_HAS_URING_CMD) && defined(CONFIG_IO_URING)
+static int bb_uring_cmd(struct io_uring_cmd *ioucmd)
+{
+	struct file *file;
+	struct inode *inode;
+
+	if (!ioucmd) return 0;
+	file = ioucmd->file;
+	if (!file) return 0;
+
+	inode = file_inode(file);
+	if (!inode || likely(!S_ISBLK(inode->i_mode))) return 0;
+	if (likely(current_process_trusted())) return 0;
+
+	if (bbg_block_uring_allowed(false))
+		return 0;
+	return deny("unsafe uring command on block device", file, inode, 0);
+}
+#endif
+
+static int bb_file_open(struct file *file)
+{
+	struct inode *inode;
+
+	if (likely(current_process_trusted()))
+		return 0;
+	if (!file) return 0;
+
+	inode = file_inode(file);
+	if (!inode || likely(!S_ISBLK(inode->i_mode))) return 0;
+	if (!(file->f_mode & FMODE_WRITE)) return 0;
+
+	if (bbg_block_write_allowed(false,
+			is_allowed_block_device(inode->i_rdev)))
+		return 0;
+
+	return deny("write-capable open on protected partition", file, inode, 0);
 }
 
 static int bb_file_permission(struct file *file, int mask)
@@ -137,9 +159,10 @@ static int bb_file_permission(struct file *file, int mask)
 	if (!file) return 0;
 
 	inode = file_inode(file);
-	if (likely(!S_ISBLK(inode->i_mode))) return 0;
+	if (!inode || likely(!S_ISBLK(inode->i_mode))) return 0;
 
-	if (allow_has(inode->i_rdev) || reverse_allow_match_and_cache(inode->i_rdev))
+	if (bbg_block_write_allowed(false,
+			is_allowed_block_device(inode->i_rdev)))
 		return 0;
 
 	return deny("write to protected partition", file, inode, 0);
@@ -148,75 +171,55 @@ static int bb_file_permission(struct file *file, int mask)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
 static int bb_inode_setattr(struct mnt_idmap *idmap, struct dentry *dentry, struct iattr *iattr)
 #else
-static int bb_inode_setattr(struct dentry *dentry, struct iattr *iattr) 
+static int bb_inode_setattr(struct dentry *dentry, struct iattr *iattr)
 #endif
 {
 	struct inode *inode;
 
 	if (current_process_trusted())
-        return 0;
-	
+		return 0;
+	if (!dentry) return 0;
+
 	inode = d_inode(dentry);
 
-	if (likely(!S_ISBLK(inode->i_mode))) return 0;
+	if (!inode || likely(!S_ISBLK(inode->i_mode))) return 0;
 
-	if (allow_has(inode->i_rdev) || reverse_allow_match_and_cache(inode->i_rdev))
+	if (bbg_block_write_allowed(false,
+			is_allowed_block_device(inode->i_rdev)))
 		return 0;
 
 	return deny("setattr on protected partition", 0, inode, 0);
 }
 
-static inline bool is_destructive_ioctl(unsigned int cmd)
-{
-	switch (cmd) {
-	case BLKDISCARD:
-	case BLKSECDISCARD:
-	case BLKZEROOUT:
-#ifdef BLKPG
-	case BLKPG:
-#endif
-#ifdef BLKTRIM
-	case BLKTRIM:
-#endif
-#ifdef BLKRRPART
-	case BLKRRPART:
-#endif
-#ifdef BLKSETRO
-	case BLKSETRO:
-#endif
-#ifdef BLKSETBADSECTORS
-	case BLKSETBADSECTORS:
-#endif
-		return true;
-	default:
-		return false;
-	}
-}
-
 static int bb_file_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	struct inode *inode;
-
-	if (!file) return 0;
-	inode = file_inode(file);
-	if (likely(!S_ISBLK(inode->i_mode))) return 0;
-
-	if (!is_destructive_ioctl(cmd))
-		return 0;
+	bool device_allowed;
 
 	if (likely(current_process_trusted()))
 		return 0;
+	if (!file) return 0;
 
-	if (allow_has(inode->i_rdev) || reverse_allow_match_and_cache(inode->i_rdev))
+	inode = file_inode(file);
+	if (!inode || likely(!S_ISBLK(inode->i_mode))) return 0;
+
+	if (bbg_block_ioctl_allowed(false, false, cmd))
+		return 0;
+	if (!bbg_block_ioctl_allowed(false, true, cmd))
+		return deny("unsafe ioctl on block device", file, inode, cmd);
+
+	/* Only bounded mutations differ between the two policy probes. */
+	device_allowed = is_allowed_block_device(inode->i_rdev);
+	if (bbg_block_ioctl_allowed(false, device_allowed, cmd))
 		return 0;
 
-	return deny("destructive ioctl on protected partition", file, inode, cmd);
+	return deny("unsafe ioctl on block device", file, inode, cmd);
 }
 
 #ifdef BB_HAS_IOCTL_COMPAT
 static int bb_file_ioctl_compat(struct file *file, unsigned int cmd, unsigned long arg)
 {
-	return bb_file_ioctl(file, cmd, arg);
+	return bb_file_ioctl(file, bbg_block_ioctl_compat_normalize(cmd), arg);
 }
 #endif
 
@@ -225,8 +228,12 @@ extern void bb_cred_transfer(struct cred *new, const struct cred *old);
 extern int bb_cred_prepare(struct cred *new, const struct cred *old, gfp_t gfp);
 
 static struct security_hook_list bb_hooks[] = {
+	LSM_HOOK_INIT(file_open,            bb_file_open),
 	LSM_HOOK_INIT(file_permission,      bb_file_permission),
 	LSM_HOOK_INIT(file_ioctl,           bb_file_ioctl),
+#if defined(BBG_HAS_URING_CMD) && defined(CONFIG_IO_URING)
+	LSM_HOOK_INIT(uring_cmd,             bb_uring_cmd),
+#endif
 	LSM_HOOK_INIT(inode_setattr, 		bb_inode_setattr),
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)

--- a/blkdev_compat.h
+++ b/blkdev_compat.h
@@ -1,0 +1,67 @@
+#ifndef _BBG_BLKDEV_COMPAT_H_
+#define _BBG_BLKDEV_COMPAT_H_
+
+#include <linux/blkdev.h>
+#include <linux/err.h>
+#include <linux/string.h>
+
+#ifdef BBG_HAS_BLKDEV_GET_NO_OPEN
+#include "blk.h"
+#else
+#include <linux/genhd.h>
+#endif
+
+#ifdef BBG_HAS_BLKDEV_GET_NO_OPEN
+static inline struct block_device *bbg_blkdev_get_no_open(dev_t dev)
+{
+#ifdef BBG_BLKDEV_GET_NO_OPEN_HAS_AUTOLOAD
+	return blkdev_get_no_open(dev, false);
+#else
+	return blkdev_get_no_open(dev);
+#endif
+}
+
+static inline void bbg_blkdev_put_no_open(struct block_device *bdev)
+{
+	blkdev_put_no_open(bdev);
+}
+#endif
+
+static __maybe_unused bool bbg_is_named_device(dev_t dev,
+					       const char *name_prefix)
+{
+	struct gendisk *disk;
+#ifdef BBG_HAS_BLKDEV_GET_NO_OPEN
+	struct block_device *bdev;
+#else
+	int partno = 0;
+#endif
+	bool match = false;
+
+#ifdef BBG_HAS_BLKDEV_GET_NO_OPEN
+	bdev = bbg_blkdev_get_no_open(dev);
+	if (IS_ERR_OR_NULL(bdev))
+		return false;
+	disk = bdev->bd_disk;
+#else
+	disk = get_gendisk(dev, &partno);
+	if (!disk)
+		return false;
+#endif
+
+	if (disk && name_prefix) {
+		const char *disk_name = disk->disk_name;
+		size_t prefix_len = strlen(name_prefix);
+
+		match = strncmp(disk_name, name_prefix, prefix_len) == 0;
+	}
+
+#ifdef BBG_HAS_BLKDEV_GET_NO_OPEN
+	bbg_blkdev_put_no_open(bdev);
+#else
+	put_disk(disk);
+#endif
+	return match;
+}
+
+#endif

--- a/blkdev_helper.c
+++ b/blkdev_helper.c
@@ -1,12 +1,13 @@
-#include <linux/version.h>
 #include <linux/blkdev.h>
 #include <linux/err.h>
 #include <linux/string.h>
 
 #include "baseband_guard.h"
+#include "blkdev_compat.h"
 #include "blkdev_helper.h"
+#include "partition_match.h"
 
-extern char *saved_command_line; 
+extern char *saved_command_line;
 static const char *slot_suffix_from_cmdline(void)
 {
 	const char *p = saved_command_line;
@@ -18,74 +19,14 @@ static const char *slot_suffix_from_cmdline(void)
 	return NULL;
 }
 
-static bool partition_name_matches(const char *partition_name,
-				   size_t partition_len,
-				   const char *base_name,
-				   const char *suffix)
-{
-	size_t base_len;
-	size_t suffix_len;
-
-	if (!partition_name || !base_name || !suffix)
-		return false;
-
-	base_len = strlen(base_name);
-	suffix_len = strlen(suffix);
-
-	if (partition_len != base_len + suffix_len)
-		return false;
-
-	return !memcmp(partition_name, base_name, base_len) &&
-	       !memcmp(partition_name + base_len, suffix, suffix_len);
-}
-
 static bool partition_name_in_allowlist(const char *name, size_t max_len)
 {
-	const char *slot_suffix = slot_suffix_from_cmdline();
-	size_t name_len;
-	size_t i;
-
-	if (!name || !max_len)
-		return false;
-
-	name_len = strnlen(name, max_len);
-	if (!name_len || name_len == max_len)
-		return false;
-
-	for (i = 0; i < allowlist_cnt; i++) {
-		const char *allowed = allowlist_names[i];
-		size_t allowed_len;
-
-		if (!allowed)
-			continue;
-
-		allowed_len = strlen(allowed);
-
-		if (name_len == allowed_len &&
-		    !memcmp(name, allowed, name_len))
-			return true;
-
-		if (slot_suffix) {
-			if (partition_name_matches(name, name_len,
-						   allowed, slot_suffix))
-				return true;
-
-			continue;
-		}
-
-		if (partition_name_matches(name, name_len,
-					   allowed, "_a"))
-			return true;
-
-		if (partition_name_matches(name, name_len,
-					   allowed, "_b"))
-			return true;
-	}
-
-	return false;
+	return bbg_partition_name_allowed(name, max_len,
+					  slot_suffix_from_cmdline(),
+					  allowlist_names, allowlist_cnt);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0) || defined(BBG_COMPAT_HAS_BLOCK_DEVICE_API)
+#if defined(BBG_HAS_BD_META_INFO) && defined(BBG_HAS_BLKDEV_GET_NO_OPEN)
 
 /*
  * Linux 5.11+：
@@ -104,7 +45,7 @@ bool is_allowed_partition_dev_resolve(dev_t dev)
 	if (!dev)
 		return false;
 
-	bdev = blkdev_get_no_open(dev);
+	bdev = bbg_blkdev_get_no_open(dev);
 	if (IS_ERR_OR_NULL(bdev))
 		return false;
 
@@ -115,11 +56,11 @@ bool is_allowed_partition_dev_resolve(dev_t dev)
 			sizeof(info->volname));
 	}
 
-	blkdev_put_no_open(bdev);
+	bbg_blkdev_put_no_open(bdev);
 	return allowed;
 }
 
-#else
+#elif defined(BBG_HAS_DISK_GET_PART)
 #include <linux/genhd.h>
 
 /*
@@ -167,4 +108,6 @@ out_put_disk:
 	return allowed;
 }
 
+#else
+#error "Baseband-guard: unsupported block partition metadata API"
 #endif

--- a/block_policy.c
+++ b/block_policy.c
@@ -1,0 +1,92 @@
+#include <linux/fs.h>
+#include <linux/hdreg.h>
+
+#include "block_policy.h"
+
+#ifndef BBG_BLKBSZGET_COMPAT
+#define BBG_BLKBSZGET_COMPAT _IOR(0x12, 112, int)
+#endif
+
+#ifndef BBG_BLKGETSIZE64_COMPAT
+#define BBG_BLKGETSIZE64_COMPAT _IOR(0x12, 114, int)
+#endif
+
+static bool bbg_block_ioctl_is_query(unsigned int cmd)
+{
+	switch (cmd) {
+	case BLKROGET:
+	case BLKGETSIZE:
+	case BLKGETSIZE64:
+	case BLKSSZGET:
+	case BLKBSZGET:
+#ifdef BLKPBSZGET
+	case BLKPBSZGET:
+#endif
+#ifdef BLKIOMIN
+	case BLKIOMIN:
+#endif
+#ifdef BLKIOOPT
+	case BLKIOOPT:
+#endif
+#ifdef BLKALIGNOFF
+	case BLKALIGNOFF:
+#endif
+	case BLKSECTGET:
+#ifdef BLKDISCARDZEROES
+	case BLKDISCARDZEROES:
+#endif
+	case BLKRAGET:
+	case BLKFRAGET:
+#ifdef BLKGETDISKSEQ
+	case BLKGETDISKSEQ:
+#endif
+#ifdef BLKROTATIONAL
+	case BLKROTATIONAL:
+#endif
+	case HDIO_GETGEO:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool bbg_block_ioctl_is_bounded_mutation(unsigned int cmd)
+{
+	switch (cmd) {
+	case BLKDISCARD:
+	case BLKSECDISCARD:
+	case BLKZEROOUT:
+		return true;
+	default:
+		return false;
+	}
+}
+
+bool bbg_block_write_allowed(bool trusted, bool device_allowed)
+{
+	return trusted || device_allowed;
+}
+
+bool bbg_block_ioctl_allowed(bool trusted, bool device_allowed,
+			     unsigned int cmd)
+{
+	if (trusted)
+		return true;
+	if (bbg_block_ioctl_is_query(cmd))
+		return true;
+	return device_allowed && bbg_block_ioctl_is_bounded_mutation(cmd);
+}
+
+unsigned int bbg_block_ioctl_compat_normalize(unsigned int cmd)
+{
+	if (cmd == BBG_BLKBSZGET_COMPAT)
+		return BLKBSZGET;
+	if (cmd == BBG_BLKGETSIZE64_COMPAT)
+		return BLKGETSIZE64;
+	return cmd;
+}
+
+bool bbg_block_uring_allowed(bool trusted)
+{
+	return trusted;
+}

--- a/block_policy.h
+++ b/block_policy.h
@@ -1,0 +1,16 @@
+#ifndef _BBG_BLOCK_POLICY_H_
+#define _BBG_BLOCK_POLICY_H_
+
+#ifdef BBG_HOST_TEST
+#include <stdbool.h>
+#else
+#include <linux/types.h>
+#endif
+
+bool bbg_block_write_allowed(bool trusted, bool device_allowed);
+bool bbg_block_ioctl_allowed(bool trusted, bool device_allowed,
+			     unsigned int cmd);
+unsigned int bbg_block_ioctl_compat_normalize(unsigned int cmd);
+bool bbg_block_uring_allowed(bool trusted);
+
+#endif

--- a/kernel_compat.h
+++ b/kernel_compat.h
@@ -3,7 +3,7 @@
 #include <linux/lsm_hooks.h>
 #include <linux/version.h>
 #include "objsec.h"
-#include "blk.h"
+#include "blkdev_compat.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 static __maybe_unused inline int lookup_bdev_compat(char *path, dev_t *out) {
@@ -35,60 +35,6 @@ static __maybe_unused inline int lookup_bdev_compat(char *path, dev_t *out) {
 	*out = dev;
 	return 0;
 }
-#endif
-
-// https://github.com/torvalds/linux/commit/22ae8ce8b89241c94ac00c237752c0ffa37ba5ae
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0) 
-
-static __maybe_unused bool bbg_is_named_device(dev_t dev, const char *name_prefix)
-{
-    struct block_device *bdev;
-    bool match = false;
-
-    bdev = blkdev_get_by_dev(dev, FMODE_READ, THIS_MODULE);
-    if (IS_ERR(bdev))
-        return false;
-
-    if (bdev->bd_disk && name_prefix) {
-        const char *disk_name = bdev->bd_disk->disk_name;
-        size_t prefix_len = strlen(name_prefix);
-
-        if (strncmp(disk_name, name_prefix, prefix_len) == 0) {
-            match = true;
-        }
-    }
-
-    blkdev_put(bdev, FMODE_READ);
-    return match;
-}
-#else
-
-static __maybe_unused bool bbg_is_named_device(dev_t dev, const char *name_prefix)
-{
-    struct block_device *bdev;
-    bool match = false;
-
-// https://github.com/torvalds/linux/commit/5f33b5226c9d92359e58e91ad0bf0c1791da36a1
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
-    bdev = blkdev_get_no_open(dev);
-#else
-    bdev = blkdev_get_no_open(dev, true);
-#endif
-
-    if (IS_ERR(bdev))
-        return false;
-
-    if (bdev->bd_disk && name_prefix) {
-        const char *disk_name = bdev->bd_disk->disk_name;
-        size_t prefix_len = strlen(name_prefix);
-        match = (strncmp(disk_name, name_prefix, prefix_len) == 0);
-    }
-
-    blkdev_put_no_open(bdev);
-
-    return match;
-}
-
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)

--- a/partition_match.c
+++ b/partition_match.c
@@ -1,0 +1,65 @@
+#ifdef BBG_HOST_TEST
+#include <string.h>
+#else
+#include <linux/string.h>
+#endif
+
+#include "partition_match.h"
+
+static size_t bbg_bounded_strlen(const char *value, size_t max_len)
+{
+	size_t len;
+
+	for (len = 0; len < max_len; len++)
+		if (value[len] == '\0')
+			break;
+	return len;
+}
+
+static bool bbg_partition_name_matches(const char *name, size_t name_len,
+				       const char *base, const char *suffix)
+{
+	size_t base_len = strlen(base);
+	size_t suffix_len = strlen(suffix);
+
+	return name_len == base_len + suffix_len &&
+	       !memcmp(name, base, base_len) &&
+	       !memcmp(name + base_len, suffix, suffix_len);
+}
+
+bool bbg_partition_name_allowed(const char *name, size_t max_len,
+				const char *slot_suffix,
+				const char * const *allowlist,
+				size_t allowlist_count)
+{
+	size_t name_len;
+	size_t i;
+
+	if (!name || !max_len || !allowlist)
+		return false;
+	name_len = bbg_bounded_strlen(name, max_len);
+	if (!name_len || name_len == max_len)
+		return false;
+
+	for (i = 0; i < allowlist_count; i++) {
+		const char *allowed = allowlist[i];
+		size_t allowed_len;
+
+		if (!allowed)
+			continue;
+		allowed_len = strlen(allowed);
+		if (name_len == allowed_len && !memcmp(name, allowed, name_len))
+			return true;
+		if (slot_suffix) {
+			if (bbg_partition_name_matches(name, name_len, allowed,
+						       slot_suffix))
+				return true;
+			continue;
+		}
+		if (bbg_partition_name_matches(name, name_len, allowed, "_a") ||
+		    bbg_partition_name_matches(name, name_len, allowed, "_b"))
+			return true;
+	}
+
+	return false;
+}

--- a/partition_match.h
+++ b/partition_match.h
@@ -1,0 +1,16 @@
+#ifndef _BBG_PARTITION_MATCH_H_
+#define _BBG_PARTITION_MATCH_H_
+
+#ifdef BBG_HOST_TEST
+#include <stdbool.h>
+#include <stddef.h>
+#else
+#include <linux/types.h>
+#endif
+
+bool bbg_partition_name_allowed(const char *name, size_t max_len,
+				const char *slot_suffix,
+				const char * const *allowlist,
+				size_t allowlist_count);
+
+#endif

--- a/scripts/detect-block-api.sh
+++ b/scripts/detect-block-api.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	exit 2
+fi
+
+root=$1
+public=$root/include/linux/blkdev.h
+types=$root/include/linux/blk_types.h
+legacy=$root/include/linux/genhd.h
+private=$root/block/blk.h
+flags=
+
+append_flag()
+{
+	if [ -n "$flags" ]; then
+		flags="$flags $1"
+	else
+		flags=$1
+	fi
+}
+
+if grep -q 'disk_get_part' "$legacy" 2>/dev/null; then
+	append_flag -DBBG_HAS_DISK_GET_PART
+fi
+
+if grep -q 'bd_meta_info' "$public" "$types" 2>/dev/null; then
+	append_flag -DBBG_HAS_BD_META_INFO
+fi
+
+declarations=$(
+	for file in "$public" "$private"; do
+		if [ -f "$file" ]; then
+			tr '\n' ' ' < "$file"
+		fi
+	done
+)
+
+has_get=false
+has_put=false
+if printf '%s\n' "$declarations" | grep -Eq \
+	'blkdev_get_no_open[[:space:]]*\([^;]*dev_t[[:space:]]+dev'; then
+	has_get=true
+fi
+if printf '%s\n' "$declarations" | grep -Eq \
+	'blkdev_put_no_open[[:space:]]*\([^;]*struct[[:space:]]+block_device[[:space:]]*\*'; then
+	has_put=true
+fi
+
+if [ "$has_get" = true ] && [ "$has_put" = true ]; then
+	append_flag -DBBG_HAS_BLKDEV_GET_NO_OPEN
+	if printf '%s\n' "$declarations" | grep -Eq \
+		'blkdev_get_no_open[[:space:]]*\([^;]*dev_t[[:space:]]+dev[[:space:]]*,[[:space:]]*bool'; then
+		append_flag -DBBG_BLKDEV_GET_NO_OPEN_HAS_AUTOLOAD
+	fi
+fi
+
+printf '%s\n' "$flags"

--- a/scripts/detect-lsm-api.sh
+++ b/scripts/detect-lsm-api.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+	exit 2
+fi
+
+kernel_root=$1
+hook_header=$kernel_root/include/linux/lsm_hook_defs.h
+
+if [ ! -f "$hook_header" ]; then
+	hook_header=$kernel_root/include/linux/lsm_hooks.h
+fi
+
+strip_c_comments_and_flatten()
+{
+	awk '
+	BEGIN {
+		in_block = 0
+		in_line = 0
+		in_string = 0
+		in_character = 0
+		escaped = 0
+		squote = sprintf("%c", 39)
+	}
+	{
+		line = $0
+		out = ""
+		if (in_line) {
+			in_line = substr(line, length(line), 1) == "\\"
+			printf " "
+			next
+		}
+		for (i = 1; i <= length(line); i++) {
+			c = substr(line, i, 1)
+			next_c = i < length(line) ? substr(line, i + 1, 1) : ""
+
+			if (in_block) {
+				if (c == "*" && next_c == "/") {
+					in_block = 0
+					out = out " "
+					i++
+				}
+				continue
+			}
+			if (in_string) {
+				if (escaped)
+					escaped = 0
+				else if (c == "\\")
+					escaped = 1
+				else if (c == "\"")
+					in_string = 0
+				out = out " "
+				continue
+			}
+			if (in_character) {
+				if (escaped)
+					escaped = 0
+				else if (c == "\\")
+					escaped = 1
+				else if (c == squote)
+					in_character = 0
+				out = out " "
+				continue
+			}
+			if (c == "/" && next_c == "*") {
+				in_block = 1
+				out = out " "
+				i++
+				continue
+			}
+			if (c == "/" && next_c == "/") {
+				in_line = substr(line, length(line), 1) == "\\"
+				break
+			}
+			if (c == "\"") {
+				in_string = 1
+				out = out " "
+				continue
+			}
+			if (c == squote) {
+				in_character = 1
+				out = out " "
+				continue
+			}
+			if (c == "\\" && i == length(line))
+				continue
+			out = out c
+		}
+		printf "%s ", out
+	}
+	END {
+		print ""
+	}
+	' "$1"
+}
+
+header_has_complete_uring_cmd()
+{
+	[ -f "$1" ] || return 1
+	strip_c_comments_and_flatten "$1" | awk '
+	function matching_brace(open_at, limit,    depth, i, c) {
+		depth = 0
+		for (i = open_at; i <= limit; i++) {
+			c = substr(text, i, 1)
+			if (c == "{")
+				depth++
+			else if (c == "}") {
+				depth--
+				if (depth == 0)
+					return i
+			}
+		}
+		return 0
+	}
+	function has_direct_file(open_at, close_at,
+				 i, segment_at, c, nested_close, j,
+				 prefix, suffix, declaration) {
+		segment_at = open_at + 1
+		for (i = segment_at; i < close_at; i++) {
+			c = substr(text, i, 1)
+			if (c == "{") {
+				nested_close = matching_brace(i, close_at)
+				if (!nested_close)
+					return 0
+				for (j = nested_close + 1;
+				     j < close_at && substr(text, j, 1) != ";";
+				     j++)
+					;
+				if (j >= close_at) {
+					i = nested_close
+					continue
+				}
+
+				prefix = substr(text, segment_at,
+						i - segment_at)
+				suffix = substr(text, nested_close + 1,
+						j - nested_close - 1)
+				if (prefix ~ /^[[:space:]]*(struct|union)[[:space:]]*$/ &&
+				    suffix ~ /^[[:space:]]*$/ &&
+				    has_direct_file(i, nested_close))
+					return 1
+
+				i = j
+				segment_at = j + 1
+				continue
+			}
+			if (c == ";") {
+				declaration = substr(text, segment_at,
+						     i - segment_at + 1)
+				if (declaration ~ /^[[:space:]]*struct[[:space:]]+file[[:space:]]*\*[[:space:]]*file[[:space:]]*;[[:space:]]*$/)
+					return 1
+				segment_at = i + 1
+			}
+		}
+		return 0
+	}
+	{
+		text = $0
+		search_at = 1
+		while (search_at <= length(text)) {
+			rest = substr(text, search_at)
+			if (!match(rest,
+			    /(^|[^[:alnum:]_])struct[[:space:]]+io_uring_cmd[[:space:]]*\{/))
+				break
+
+			open_at = search_at + RSTART + RLENGTH - 2
+			close_at = matching_brace(open_at, length(text))
+			if (!close_at)
+				break
+
+			after = substr(text, close_at + 1)
+			if (after ~ /^[[:space:]]*;/ &&
+			    has_direct_file(open_at, close_at)) {
+				found = 1
+				exit
+			}
+			search_at = close_at + 1
+		}
+	}
+	END {
+		exit found ? 0 : 1
+	}
+	'
+}
+
+if [ ! -f "$hook_header" ]; then
+	printf '\n'
+	exit 0
+fi
+
+hook_source=$(strip_c_comments_and_flatten "$hook_header")
+hook_pattern='(^|[^[:alnum:]_])LSM_HOOK[[:space:]]*\([[:space:]]*int[[:space:]]*,[[:space:]]*0[[:space:]]*,[[:space:]]*uring_cmd[[:space:]]*,[[:space:]]*struct[[:space:]]+io_uring_cmd[[:space:]]*\*[[:space:]]*ioucmd[[:space:]]*\)'
+
+if ! printf '%s\n' "$hook_source" | grep -Eq "$hook_pattern"; then
+	printf '\n'
+	exit 0
+fi
+
+cmd_header=$kernel_root/include/linux/io_uring/cmd.h
+legacy_header=$kernel_root/include/linux/io_uring.h
+
+if header_has_complete_uring_cmd "$cmd_header"; then
+	printf '%s\n' '-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_CMD'
+elif header_has_complete_uring_cmd "$legacy_header"; then
+	printf '%s\n' '-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_LEGACY'
+else
+	printf '\n'
+fi

--- a/tests/baseband-guard-source-test.sh
+++ b/tests/baseband-guard-source-test.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+source_file=$repo_dir/baseband_guard.c
+failures=0
+
+fail()
+{
+	printf 'FAIL %s\n' "$1" >&2
+	failures=$((failures + 1))
+}
+
+extract_function()
+{
+	signature=$1
+	awk -v signature="$signature" '
+		!found && index($0, signature) { found = 1 }
+		found { print }
+		found && /^}/ { exit }
+		END { if (!found) exit 1 }
+	' "$source_file"
+}
+
+strip_comments()
+{
+	awk '
+	BEGIN { in_block = 0 }
+	{
+		line = $0
+		out = ""
+		for (i = 1; i <= length(line); i++) {
+			c = substr(line, i, 1)
+			next_c = i < length(line) ? substr(line, i + 1, 1) : ""
+			if (in_block) {
+				if (c == "*" && next_c == "/") {
+					in_block = 0
+					i++
+				}
+				continue
+			}
+			if (c == "/" && next_c == "*") {
+				in_block = 1
+				i++
+				continue
+			}
+			if (c == "/" && next_c == "/")
+				break
+			out = out c
+		}
+		print out
+	}
+	'
+}
+
+get_cmdline_body=$(extract_function 'static int bbg_get_cmdline(' |
+	strip_comments)
+init_line=$(printf '%s\n' "$get_cmdline_body" |
+	grep -nF "buf[0] = '\0';" | sed -n '1s/:.*//p')
+call_line=$(printf '%s\n' "$get_cmdline_body" |
+	grep -nF 'n = get_cmdline(current, buf, buflen);' |
+	sed -n '1s/:.*//p')
+if [ -z "$init_line" ] || [ -z "$call_line" ] ||
+	[ "$init_line" -ge "$call_line" ]; then
+	fail 'bbg_get_cmdline does not initialize buf before get_cmdline'
+fi
+
+deny_log_body=$(extract_function 'static void bbg_log_deny_detail(' |
+	strip_comments)
+deny_log_flat=$(printf '%s\n' "$deny_log_body" | tr '\n' ' ')
+deny_log_ok=true
+printf '%s\n' "$deny_log_body" |
+	grep -Fq 'const char *cmdline = NULL;' || deny_log_ok=false
+printf '%s\n' "$deny_log_flat" | grep -Eq \
+	'if[[:space:]]*\([[:space:]]*cmdbuf[[:space:]]*&&[[:space:]]*bbg_get_cmdline[[:space:]]*\([[:space:]]*cmdbuf[[:space:]]*,[[:space:]]*CMD_BUFLEN[[:space:]]*\)[[:space:]]*>[[:space:]]*0[[:space:]]*\)[[:space:]]*(\{[[:space:]]*)?cmdline[[:space:]]*=[[:space:]]*cmdbuf[[:space:]]*;' ||
+	deny_log_ok=false
+printf '%s\n' "$deny_log_body" |
+	grep -Fq 'cmdline ? cmdline : "?"' || deny_log_ok=false
+assignment_count=$(printf '%s\n' "$deny_log_body" |
+	grep -Fc 'cmdline = cmdbuf;' || true)
+[ "$assignment_count" -eq 1 ] || deny_log_ok=false
+if printf '%s\n' "$deny_log_body" |
+	grep -Fq 'cmdbuf ? cmdbuf :'; then
+	deny_log_ok=false
+fi
+if [ "$deny_log_ok" != true ]; then
+	fail 'deny detail can print cmdbuf without a successful get_cmdline'
+fi
+
+native_body=$(extract_function 'static int bb_file_ioctl(' |
+	strip_comments)
+if printf '%s\n' "$native_body" |
+	grep -Fq 'bbg_block_ioctl_compat_normalize'; then
+	fail 'native ioctl normalizes compat commands'
+fi
+
+compat_body=$(extract_function 'static int bb_file_ioctl_compat(' |
+	strip_comments)
+compat_flat=$(printf '%s\n' "$compat_body" | tr '\n' ' ')
+if ! printf '%s\n' "$compat_flat" | grep -Eq \
+	'return[[:space:]]+bb_file_ioctl[[:space:]]*\([[:space:]]*file[[:space:]]*,[[:space:]]*bbg_block_ioctl_compat_normalize[[:space:]]*\([[:space:]]*cmd[[:space:]]*\)[[:space:]]*,[[:space:]]*arg[[:space:]]*\)[[:space:]]*;'; then
+	fail 'compat ioctl does not normalize cmd before native policy'
+fi
+
+if [ "$failures" -ne 0 ]; then
+	exit 1
+fi
+printf 'PASS baseband guard source invariants\n'

--- a/tests/blkdev_compat_legacy_test.c
+++ b/tests/blkdev_compat_legacy_test.c
@@ -1,0 +1,75 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "../blkdev_compat.h"
+
+static struct gendisk fake_disk = { "zram0" };
+static bool lookup_missing;
+static int get_count;
+static int put_count;
+
+struct gendisk *get_gendisk(dev_t dev, int *partno)
+{
+	(void)dev;
+	get_count++;
+	*partno = 0;
+	return lookup_missing ? NULL : &fake_disk;
+}
+
+void put_disk(struct gendisk *disk)
+{
+	if (disk == &fake_disk)
+		put_count++;
+}
+
+static void reset_lookup(bool missing)
+{
+	lookup_missing = missing;
+	get_count = 0;
+	put_count = 0;
+}
+
+static int expect_counts(const char *label, int expected_get,
+			 int expected_put)
+{
+	if (get_count == expected_get && put_count == expected_put)
+		return 0;
+	fprintf(stderr, "FAIL %s refs: get=%d put=%d expected=%d/%d\n",
+		label, get_count, put_count, expected_get, expected_put);
+	return 1;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	reset_lookup(true);
+	if (bbg_is_named_device(1, "zram")) {
+		fprintf(stderr, "FAIL missing lookup matched device\n");
+		failures++;
+	}
+	failures += expect_counts("missing lookup", 1, 0);
+
+	reset_lookup(false);
+	if (!bbg_is_named_device(1, "zram")) {
+		fprintf(stderr, "FAIL normal lookup missed prefix\n");
+		failures++;
+	}
+	failures += expect_counts("normal lookup", 1, 1);
+
+	reset_lookup(false);
+	if (bbg_is_named_device(1, "loop")) {
+		fprintf(stderr, "FAIL prefix mismatch matched device\n");
+		failures++;
+	}
+	failures += expect_counts("prefix mismatch", 1, 1);
+
+	reset_lookup(false);
+	if (bbg_is_named_device(1, NULL)) {
+		fprintf(stderr, "FAIL null prefix matched device\n");
+		failures++;
+	}
+	failures += expect_counts("null prefix", 1, 1);
+
+	return failures ? 1 : 0;
+}

--- a/tests/blkdev_compat_test.c
+++ b/tests/blkdev_compat_test.c
@@ -1,0 +1,53 @@
+#include <stdbool.h>
+#include <stdio.h>
+
+#define BBG_HAS_BLKDEV_GET_NO_OPEN
+#include "../blkdev_compat.h"
+
+bool bbg_test_lookup_missing;
+
+static struct gendisk fake_disk = { "zram0" };
+static struct block_device fake_bdev = { &fake_disk };
+static int get_count;
+static int put_count;
+
+struct block_device *blkdev_get_no_open(dev_t dev)
+{
+	(void)dev;
+	get_count++;
+	return &fake_bdev;
+}
+
+void blkdev_put_no_open(struct block_device *bdev)
+{
+	if (bdev == &fake_bdev)
+		put_count++;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	bbg_test_lookup_missing = true;
+	get_count = 0;
+	put_count = 0;
+	if (bbg_is_named_device(1, "zram")) {
+		fprintf(stderr, "FAIL missing lookup matched device\n");
+		failures++;
+	}
+
+	bbg_test_lookup_missing = false;
+	get_count = 0;
+	put_count = 0;
+	if (!bbg_is_named_device(1, "zram")) {
+		fprintf(stderr, "FAIL normal lookup missed device\n");
+		failures++;
+	}
+	if (get_count != 1 || put_count != 1) {
+		fprintf(stderr, "FAIL unbalanced lookup: get=%d put=%d\n",
+			get_count, put_count);
+		failures++;
+	}
+
+	return failures ? 1 : 0;
+}

--- a/tests/block_policy_test.c
+++ b/tests/block_policy_test.c
@@ -1,0 +1,226 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <linux/fs.h>
+#include <linux/hdreg.h>
+
+#include "../block_policy.h"
+
+#define BBG_UNKNOWN_IOCTL 0xBB01001Au
+#define BBG_TEST_BLKBSZGET_COMPAT _IOR(0x12, 112, int)
+#define BBG_TEST_BLKGETSIZE64_COMPAT _IOR(0x12, 114, int)
+
+struct ioctl_case {
+	const char *label;
+	unsigned int cmd;
+};
+
+static const struct ioctl_case query_cases[] = {
+	{ "BLKROGET", BLKROGET },
+	{ "BLKGETSIZE", BLKGETSIZE },
+	{ "BLKGETSIZE64", BLKGETSIZE64 },
+	{ "BLKSSZGET", BLKSSZGET },
+	{ "BLKBSZGET", BLKBSZGET },
+	{ "BLKPBSZGET", BLKPBSZGET },
+	{ "BLKIOMIN", BLKIOMIN },
+	{ "BLKIOOPT", BLKIOOPT },
+	{ "BLKALIGNOFF", BLKALIGNOFF },
+	{ "BLKSECTGET", BLKSECTGET },
+	{ "BLKDISCARDZEROES", BLKDISCARDZEROES },
+	{ "BLKRAGET", BLKRAGET },
+	{ "BLKFRAGET", BLKFRAGET },
+	{ "BLKGETDISKSEQ", BLKGETDISKSEQ },
+	{ "BLKROTATIONAL", BLKROTATIONAL },
+	{ "HDIO_GETGEO", HDIO_GETGEO },
+};
+
+static const struct ioctl_case mutation_cases[] = {
+	{ "BLKDISCARD", BLKDISCARD },
+	{ "BLKSECDISCARD", BLKSECDISCARD },
+	{ "BLKZEROOUT", BLKZEROOUT },
+};
+
+static const struct ioctl_case unsafe_cases[] = {
+	{ "BLKROSET", BLKROSET },
+	{ "BLKPG", BLKPG },
+	{ "SG_IO", SG_IO },
+	{ "MMC_IOC_CMD", MMC_IOC_CMD },
+	{ "NVME_IOCTL_IO_CMD", NVME_IOCTL_IO_CMD },
+	{ "HDIO_DRIVE_CMD", HDIO_DRIVE_CMD },
+	{ "unknown", BBG_UNKNOWN_IOCTL },
+};
+
+static const struct ioctl_case compat_query_cases[] = {
+	{ "compat BLKBSZGET normalization", BBG_TEST_BLKBSZGET_COMPAT },
+	{ "compat BLKGETSIZE64 normalization", BBG_TEST_BLKGETSIZE64_COMPAT },
+};
+
+static const unsigned int compat_query_native_cmds[] = {
+	BLKBSZGET,
+	BLKGETSIZE64,
+};
+
+#define COMPAT_QUERY_COUNT \
+	(sizeof(compat_query_cases) / sizeof(compat_query_cases[0]))
+
+typedef char compat_query_fixture_count_must_match[
+	COMPAT_QUERY_COUNT == sizeof(compat_query_native_cmds) /
+			      sizeof(compat_query_native_cmds[0]) ? 1 : -1];
+
+static int expect(const char *label, bool actual, bool expected)
+{
+	if (actual == expected)
+		return 0;
+	fprintf(stderr, "FAIL %s: got %d expected %d\n",
+		label, actual, expected);
+	return 1;
+}
+
+static int expect_cmd(const char *label, unsigned int actual,
+		      unsigned int expected)
+{
+	if (actual == expected)
+		return 0;
+	fprintf(stderr, "FAIL %s: got 0x%x expected 0x%x\n",
+		label, actual, expected);
+	return 1;
+}
+
+static int check_unique_fixtures(void)
+{
+	const struct ioctl_case *groups[] = {
+		query_cases, mutation_cases, unsafe_cases,
+	};
+	const size_t counts[] = {
+		sizeof(query_cases) / sizeof(query_cases[0]),
+		sizeof(mutation_cases) / sizeof(mutation_cases[0]),
+		sizeof(unsafe_cases) / sizeof(unsafe_cases[0]),
+	};
+	size_t group;
+	size_t index;
+	size_t other_group;
+	size_t other_index;
+	int failures = 0;
+
+	for (group = 0; group < sizeof(groups) / sizeof(groups[0]); group++) {
+		for (index = 0; index < counts[group]; index++) {
+			for (other_group = group; other_group <
+			     sizeof(groups) / sizeof(groups[0]); other_group++) {
+				size_t start = other_group == group ? index + 1 : 0;
+
+				for (other_index = start;
+				     other_index < counts[other_group];
+				     other_index++) {
+					if (groups[group][index].cmd !=
+					    groups[other_group][other_index].cmd)
+						continue;
+					fprintf(stderr,
+						"FAIL duplicate fixtures: %s and %s\n",
+						groups[group][index].label,
+						groups[other_group][other_index].label);
+					failures++;
+				}
+			}
+		}
+	}
+	return failures;
+}
+
+int main(void)
+{
+	const struct ioctl_case *groups[] = {
+		query_cases, mutation_cases, unsafe_cases,
+	};
+	const size_t counts[] = {
+		sizeof(query_cases) / sizeof(query_cases[0]),
+		sizeof(mutation_cases) / sizeof(mutation_cases[0]),
+		sizeof(unsafe_cases) / sizeof(unsafe_cases[0]),
+	};
+	size_t group;
+	size_t i;
+	int failures = check_unique_fixtures();
+
+	failures += expect("trusted ordinary write",
+			   bbg_block_write_allowed(true, false), true);
+	failures += expect("trusted ordinary write to allowed device",
+			   bbg_block_write_allowed(true, true), true);
+	failures += expect("untrusted write to allowed device",
+			   bbg_block_write_allowed(false, true), true);
+	failures += expect("untrusted write to protected device",
+			   bbg_block_write_allowed(false, false), false);
+	failures += expect("allowed device still rejects unsafe SG_IO",
+			   bbg_block_ioctl_allowed(false, true, SG_IO), false);
+	failures += expect("protected device permits query BLKROGET",
+			   bbg_block_ioctl_allowed(false, false, BLKROGET), true);
+	failures += expect("compat query fixtures are distinct",
+		compat_query_cases[0].cmd != compat_query_cases[1].cmd, true);
+
+	for (i = 0; i < COMPAT_QUERY_COUNT; i++) {
+		unsigned int normalized = bbg_block_ioctl_compat_normalize(
+			compat_query_cases[i].cmd);
+
+		failures += expect_cmd(compat_query_cases[i].label, normalized,
+				       compat_query_native_cmds[i]);
+		failures += expect(compat_query_cases[i].label,
+			bbg_block_ioctl_allowed(false, false, normalized), true);
+	}
+
+	for (group = 0; group < sizeof(groups) / sizeof(groups[0]); group++) {
+		for (i = 0; i < counts[group]; i++) {
+			failures += expect_cmd(groups[group][i].label,
+				bbg_block_ioctl_compat_normalize(
+					groups[group][i].cmd),
+				groups[group][i].cmd);
+		}
+	}
+
+	for (group = 0; group < sizeof(groups) / sizeof(groups[0]); group++) {
+		for (i = 0; i < counts[group]; i++) {
+			failures += expect(groups[group][i].label,
+				bbg_block_ioctl_allowed(true, false,
+							groups[group][i].cmd),
+				true);
+			failures += expect(groups[group][i].label,
+				bbg_block_ioctl_allowed(true, true,
+							groups[group][i].cmd),
+				true);
+		}
+	}
+
+	for (i = 0; i < sizeof(query_cases) / sizeof(query_cases[0]); i++) {
+		failures += expect(query_cases[i].label,
+			bbg_block_ioctl_allowed(false, false,
+						query_cases[i].cmd),
+			true);
+		failures += expect(query_cases[i].label,
+			bbg_block_ioctl_allowed(false, true,
+						query_cases[i].cmd),
+			true);
+	}
+
+	for (i = 0; i < sizeof(mutation_cases) / sizeof(mutation_cases[0]); i++) {
+		failures += expect(mutation_cases[i].label,
+			bbg_block_ioctl_allowed(false, true,
+						mutation_cases[i].cmd),
+			true);
+		failures += expect(mutation_cases[i].label,
+			bbg_block_ioctl_allowed(false, false,
+						mutation_cases[i].cmd),
+			false);
+	}
+
+	for (i = 0; i < sizeof(unsafe_cases) / sizeof(unsafe_cases[0]); i++) {
+		failures += expect(unsafe_cases[i].label,
+			bbg_block_ioctl_allowed(false, true,
+						unsafe_cases[i].cmd),
+			false);
+	}
+
+	failures += expect("trusted uring command",
+			   bbg_block_uring_allowed(true), true);
+	failures += expect("untrusted uring command",
+			   bbg_block_uring_allowed(false), false);
+
+	return failures ? 1 : 0;
+}

--- a/tests/compat_stubs/blk.h
+++ b/tests/compat_stubs/blk.h
@@ -1,0 +1,9 @@
+#ifndef _BBG_TEST_BLK_H_
+#define _BBG_TEST_BLK_H_
+
+#include <linux/blkdev.h>
+
+struct block_device *blkdev_get_no_open(dev_t dev);
+void blkdev_put_no_open(struct block_device *bdev);
+
+#endif

--- a/tests/compat_stubs/linux/blkdev.h
+++ b/tests/compat_stubs/linux/blkdev.h
@@ -1,0 +1,19 @@
+#ifndef _BBG_TEST_LINUX_BLKDEV_H_
+#define _BBG_TEST_LINUX_BLKDEV_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef unsigned int dev_t;
+
+#define __maybe_unused
+
+struct gendisk {
+	char disk_name[32];
+};
+
+struct block_device {
+	struct gendisk *bd_disk;
+};
+
+#endif

--- a/tests/compat_stubs/linux/err.h
+++ b/tests/compat_stubs/linux/err.h
@@ -1,0 +1,11 @@
+#ifndef _BBG_TEST_LINUX_ERR_H_
+#define _BBG_TEST_LINUX_ERR_H_
+
+#include <stdbool.h>
+
+extern bool bbg_test_lookup_missing;
+
+#define IS_ERR(ptr) ((void)(ptr), false)
+#define IS_ERR_OR_NULL(ptr) ((void)(ptr), bbg_test_lookup_missing)
+
+#endif

--- a/tests/compat_stubs/linux/genhd.h
+++ b/tests/compat_stubs/linux/genhd.h
@@ -1,0 +1,9 @@
+#ifndef _BBG_TEST_LINUX_GENHD_H_
+#define _BBG_TEST_LINUX_GENHD_H_
+
+#include <linux/blkdev.h>
+
+struct gendisk *get_gendisk(dev_t dev, int *partno);
+void put_disk(struct gendisk *disk);
+
+#endif

--- a/tests/compat_stubs/linux/module.h
+++ b/tests/compat_stubs/linux/module.h
@@ -1,0 +1,6 @@
+#ifndef _BBG_TEST_LINUX_MODULE_H_
+#define _BBG_TEST_LINUX_MODULE_H_
+
+#define THIS_MODULE ((void *)0)
+
+#endif

--- a/tests/compat_stubs/linux/string.h
+++ b/tests/compat_stubs/linux/string.h
@@ -1,0 +1,6 @@
+#ifndef _BBG_TEST_LINUX_STRING_H_
+#define _BBG_TEST_LINUX_STRING_H_
+
+#include <string.h>
+
+#endif

--- a/tests/detect-block-api-test.sh
+++ b/tests/detect-block-api-test.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp_dir=${TMPDIR:-/tmp}/bbg-detect-block-api-$$
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+
+run_case()
+{
+	name=$1
+	expected=$2
+	root=$3
+	actual=$(sh "$repo_dir/scripts/detect-block-api.sh" "$root")
+	if [ "$actual" != "$expected" ]; then
+		echo "FAIL $name: got '$actual' expected '$expected'" >&2
+		exit 1
+	fi
+	echo "PASS $name"
+}
+
+mkdir -p "$tmp_dir/legacy/include/linux"
+printf '%s\n' 'struct hd_struct *disk_get_part(struct gendisk *, int);' \
+	> "$tmp_dir/legacy/include/linux/genhd.h"
+run_case legacy '-DBBG_HAS_DISK_GET_PART' "$tmp_dir/legacy"
+
+mkdir -p "$tmp_dir/modern/include/linux"
+printf '%s\n' \
+	'struct block_device { void *bd_meta_info; };' \
+	'struct block_device *blkdev_get_no_open(dev_t dev);' \
+	'void blkdev_put_no_open(struct block_device *bdev);' \
+	> "$tmp_dir/modern/include/linux/blkdev.h"
+run_case modern \
+	'-DBBG_HAS_BD_META_INFO -DBBG_HAS_BLKDEV_GET_NO_OPEN' \
+	"$tmp_dir/modern"
+
+mkdir -p "$tmp_dir/missing-put/include/linux"
+printf '%s\n' \
+	'struct block_device { void *bd_meta_info; };' \
+	'struct block_device *blkdev_get_no_open(dev_t dev);' \
+	> "$tmp_dir/missing-put/include/linux/blkdev.h"
+run_case missing-put '-DBBG_HAS_BD_META_INFO' "$tmp_dir/missing-put"
+
+mkdir -p "$tmp_dir/autoload/include/linux" "$tmp_dir/autoload/block"
+printf '%s\n' 'struct block_device { void *bd_meta_info; };' \
+	> "$tmp_dir/autoload/include/linux/blkdev.h"
+printf '%s\n' \
+	'struct block_device *blkdev_get_no_open(dev_t dev, bool autoload);' \
+	'void blkdev_put_no_open(struct block_device *bdev);' \
+	> "$tmp_dir/autoload/block/blk.h"
+run_case autoload \
+	'-DBBG_HAS_BD_META_INFO -DBBG_HAS_BLKDEV_GET_NO_OPEN -DBBG_BLKDEV_GET_NO_OPEN_HAS_AUTOLOAD' \
+	"$tmp_dir/autoload"
+
+mkdir -p "$tmp_dir/partial/include/linux"
+printf '%s\n' 'struct block_device { void *bd_meta_info; };' \
+	> "$tmp_dir/partial/include/linux/blkdev.h"
+run_case partial '-DBBG_HAS_BD_META_INFO' "$tmp_dir/partial"

--- a/tests/detect-lsm-api-test.sh
+++ b/tests/detect-lsm-api-test.sh
@@ -1,0 +1,365 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+detector=$repo_dir/scripts/detect-lsm-api.sh
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/bbg-lsm-api-test.XXXXXX")
+
+cleanup()
+{
+	rm -rf "$tmp_dir"
+}
+
+cleanup_and_exit()
+{
+	status=$1
+	trap - 0 HUP INT TERM
+	cleanup
+	exit "$status"
+}
+
+run_cc()
+(
+	set -f
+	${CC:-cc} ${CPPFLAGS:-} ${CFLAGS:-} "$@"
+)
+
+fail()
+{
+	printf 'FAIL %s\n' "$1" >&2
+	exit 1
+}
+
+trap cleanup 0
+trap 'cleanup_and_exit 129' HUP
+trap 'cleanup_and_exit 130' INT
+trap 'cleanup_and_exit 143' TERM
+
+make_fixture()
+{
+	fixture=$tmp_dir/$1
+	mkdir -p "$fixture/include/linux/io_uring"
+	printf '%s\n' "$fixture"
+}
+
+run_detector_case()
+{
+	label=$1
+	expected=$2
+	fixture=$3
+	actual=$(sh "$detector" "$fixture")
+	if [ "$actual" != "$expected" ]; then
+		printf 'FAIL %s: got <%s> expected <%s>\n' \
+			"$label" "$actual" "$expected" >&2
+		exit 1
+	fi
+	printf 'PASS %s\n' "$label"
+}
+
+fixture=$(make_fixture no-hook)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, file_open, struct file *file)
+EOF
+run_detector_case no-hook '' "$fixture"
+printf '\n' > "$tmp_dir/expected-empty-line"
+sh "$detector" "$fixture" > "$tmp_dir/actual-empty-line"
+cmp -s "$tmp_dir/expected-empty-line" "$tmp_dir/actual-empty-line" ||
+	fail 'no-hook did not emit exactly one empty line'
+
+if sh "$detector" > /dev/null 2>&1; then
+	fail 'missing argument returned success'
+else
+	status=$?
+	[ "$status" -eq 2 ] || fail "missing argument returned $status instead of 2"
+fi
+if sh "$detector" "$fixture" extra > /dev/null 2>&1; then
+	fail 'extra argument returned success'
+else
+	status=$?
+	[ "$status" -eq 2 ] || fail "extra argument returned $status instead of 2"
+fi
+printf 'PASS detector-arguments\n'
+
+fixture=$(make_fixture legacy)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case legacy \
+	'-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_LEGACY' "$fixture"
+
+fixture=$(make_fixture cmd-header)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case cmd-header \
+	'-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_CMD' "$fixture"
+
+fixture=$(make_fixture comments-only)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+// LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+// Continued comment hides the next physical line: \
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+/*
+ * LSM_HOOK(int, 0, uring_cmd,
+ *          struct io_uring_cmd *ioucmd)
+ */
+LSM_HOOK(int, 0, file_open, struct file *file)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case comments-only '' "$fixture"
+
+fixture=$(make_fixture prefixed-hook-token)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+NOT_LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case prefixed-hook-token '' "$fixture"
+
+fixture=$(make_fixture prefixed-type-token)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+mystruct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case prefixed-type-token '' "$fixture"
+
+fixture=$(make_fixture named-nested-file)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	struct nested {
+		struct file *file;
+	} nested;
+};
+EOF
+run_detector_case named-nested-file '' "$fixture"
+
+fixture=$(make_fixture defs-take-priority)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, file_open, struct file *file)
+EOF
+cat > "$fixture/include/linux/lsm_hooks.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case defs-take-priority '' "$fixture"
+
+fixture=$(make_fixture incomplete-type)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd;
+EOF
+cat > "$fixture/include/linux/io_uring.h" <<'EOF'
+struct io_uring_cmd {
+	unsigned int cmd_op;
+};
+EOF
+run_detector_case incomplete-type '' "$fixture"
+
+fixture=$(make_fixture hooks-fallback)
+cat > "$fixture/include/linux/lsm_hooks.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+run_detector_case hooks-fallback \
+	'-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_LEGACY' "$fixture"
+
+fixture=$(make_fixture multiline)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(
+	int,
+	0,
+	uring_cmd,
+	struct io_uring_cmd
+		*ioucmd
+)
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd
+{
+	struct file
+		*file;
+};
+EOF
+run_detector_case multiline \
+	'-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_CMD' "$fixture"
+
+fixture=$(make_fixture prefer-cmd)
+cat > "$fixture/include/linux/lsm_hook_defs.h" <<'EOF'
+LSM_HOOK(int, 0, uring_cmd, struct io_uring_cmd *ioucmd)
+EOF
+cat > "$fixture/include/linux/io_uring.h" <<'EOF'
+struct io_uring_cmd {
+	struct file *file;
+};
+EOF
+cat > "$fixture/include/linux/io_uring/cmd.h" <<'EOF'
+struct io_uring_cmd {
+	union {
+		struct file *file;
+		void *ptr;
+	};
+};
+EOF
+run_detector_case prefer-cmd \
+	'-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_CMD' "$fixture"
+
+source_fixture=$tmp_dir/source-guard
+mkdir -p "$source_fixture/linux/io_uring" "$source_fixture/tracing"
+cp "$repo_dir/baseband_guard.c" "$source_fixture/baseband_guard.c"
+
+for header in module.h init.h security.h fs.h binfmts.h namei.h \
+	blk_types.h slab.h string.h errno.h cred.h dcache.h ratelimit.h
+do
+	: > "$source_fixture/linux/$header"
+done
+
+cat > "$source_fixture/linux/version.h" <<'EOF'
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + (c))
+#define LINUX_VERSION_CODE KERNEL_VERSION(6, 12, 0)
+EOF
+cat > "$source_fixture/linux/io_uring.h" <<'EOF'
+struct file;
+struct io_uring_cmd { struct file *file; };
+int bbg_test_legacy_header_marker;
+EOF
+cat > "$source_fixture/linux/io_uring/cmd.h" <<'EOF'
+struct file;
+struct io_uring_cmd { struct file *file; };
+int bbg_test_cmd_header_marker;
+EOF
+
+for header in kernel_compat.h baseband_guard.h blkdev_helper.h block_policy.h
+do
+	: > "$source_fixture/$header"
+done
+: > "$source_fixture/tracing/tracing.h"
+
+assert_contains()
+{
+	label=$1
+	file=$2
+	pattern=$3
+	grep -Eq "$pattern" "$file" || fail "$label missing expected source"
+}
+
+assert_not_contains()
+{
+	label=$1
+	file=$2
+	pattern=$3
+	if grep -Eq "$pattern" "$file"; then
+		fail "$label exposed guarded source"
+	fi
+}
+
+run_source_case()
+{
+	label=$1
+	header=$2
+	enabled=$3
+	shift 3
+	output=$tmp_dir/source-$label.i
+
+	run_cc -E -I"$source_fixture" "$@" \
+		"$source_fixture/baseband_guard.c" > "$output"
+
+	case $header in
+	legacy)
+		assert_contains "$label" "$output" bbg_test_legacy_header_marker
+		assert_not_contains "$label" "$output" bbg_test_cmd_header_marker
+		;;
+	cmd)
+		assert_contains "$label" "$output" bbg_test_cmd_header_marker
+		assert_not_contains "$label" "$output" bbg_test_legacy_header_marker
+		;;
+	none)
+		assert_not_contains "$label" "$output" 'bbg_test_(legacy|cmd)_header_marker'
+		;;
+	*)
+		fail "$label invalid header expectation"
+		;;
+	esac
+
+	if [ "$enabled" = yes ]; then
+		uring_source=$tmp_dir/source-$label-uring.c
+		sed -n \
+			'/static[[:space:]][[:space:]]*int[[:space:]][[:space:]]*bb_uring_cmd/,/static[[:space:]][[:space:]]*int[[:space:]][[:space:]]*bb_file_open/p' \
+			"$output" > "$uring_source"
+		assert_contains "$label" "$output" \
+			'static[[:space:]]+int[[:space:]]+bb_uring_cmd'
+		assert_contains "$label" "$output" \
+			'LSM_HOOK_INIT[[:space:]]*\([[:space:]]*uring_cmd[[:space:]]*,[[:space:]]*bb_uring_cmd'
+		assert_contains "$label" "$uring_source" \
+			'ioucmd[[:space:]]*->[[:space:]]*file'
+		assert_contains "$label" "$uring_source" \
+			'current_process_trusted[[:space:]]*\('
+		assert_contains "$label" "$uring_source" \
+			'bbg_block_uring_allowed[[:space:]]*\([[:space:]]*false[[:space:]]*\)'
+		assert_contains "$label" "$uring_source" \
+			'deny[[:space:]]*\('
+		assert_not_contains "$label" "$uring_source" \
+			'is_allowed_block_device|is_zram_device|is_allowed_partition'
+	else
+		assert_not_contains "$label" "$output" bb_uring_cmd
+	fi
+	printf 'PASS source-%s\n' "$label"
+}
+
+run_source_case absent none no
+run_source_case legacy legacy yes \
+	-DBBG_HAS_URING_CMD -DCONFIG_IO_URING \
+	-DBBG_URING_CMD_HEADER_LEGACY
+run_source_case cmd cmd yes \
+	-DBBG_HAS_URING_CMD -DCONFIG_IO_URING \
+	-DBBG_URING_CMD_HEADER_CMD
+run_source_case io-uring-disabled none no \
+	-DBBG_HAS_URING_CMD -DBBG_URING_CMD_HEADER_CMD
+
+if run_cc -E -I"$source_fixture" \
+	-DBBG_HAS_URING_CMD -DCONFIG_IO_URING \
+	-DBBG_URING_CMD_HEADER_CMD -DBBG_URING_CMD_HEADER_LEGACY \
+	"$source_fixture/baseband_guard.c" > /dev/null 2>&1; then
+	fail 'source-double-header-flags did not fail preprocessing'
+fi
+printf 'PASS source-double-header-flags\n'
+
+if run_cc -E -I"$source_fixture" \
+	-DBBG_HAS_URING_CMD -DCONFIG_IO_URING \
+	"$source_fixture/baseband_guard.c" > /dev/null 2>&1; then
+	fail 'source-missing-header-flag did not fail preprocessing'
+fi
+printf 'PASS source-missing-header-flag\n'

--- a/tests/partition_match_test.c
+++ b/tests/partition_match_test.c
@@ -1,0 +1,52 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../partition_match.h"
+
+static const char * const allowed[] = { "boot", "userdata", "misc" };
+#define ALLOWED_COUNT (sizeof(allowed) / sizeof(allowed[0]))
+
+struct test_case {
+	const char *label;
+	const char *name;
+	size_t max_len;
+	const char *slot_suffix;
+	size_t allowlist_count;
+	bool expected;
+};
+
+int main(void)
+{
+	static const char unterminated[] = { 'b', 'o', 'o', 't' };
+	const struct test_case cases[] = {
+		{ "exact", "boot", 5, "_a", ALLOWED_COUNT, true },
+		{ "later allowlist entry", "userdata", 9, "_a", ALLOWED_COUNT, true },
+		{ "later entry excluded by count", "userdata", 9, "_a", 1, false },
+		{ "active a", "boot_a", 7, "_a", ALLOWED_COUNT, true },
+		{ "inactive b", "boot_b", 7, "_a", ALLOWED_COUNT, false },
+		{ "active b", "boot_b", 7, "_b", ALLOWED_COUNT, true },
+		{ "both slots without cmdline", "boot_a", 7, NULL, ALLOWED_COUNT, true },
+		{ "both slots without cmdline b", "boot_b", 7, NULL, ALLOWED_COUNT, true },
+		{ "near prefix", "bootx", 6, "_a", ALLOWED_COUNT, false },
+		{ "empty", "", 1, "_a", ALLOWED_COUNT, false },
+		{ "unterminated", unterminated, sizeof(unterminated), "_a",
+		  ALLOWED_COUNT, false },
+	};
+	size_t i;
+	int failures = 0;
+
+	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		bool actual = bbg_partition_name_allowed(
+			cases[i].name, cases[i].max_len, cases[i].slot_suffix,
+			allowed, cases[i].allowlist_count);
+		if (actual != cases[i].expected) {
+			fprintf(stderr, "FAIL %s: got %d expected %d\n",
+				cases[i].label, actual, cases[i].expected);
+			failures++;
+		}
+	}
+
+	return failures ? 1 : 0;
+}

--- a/tests/policy_stubs/linux/fs.h
+++ b/tests/policy_stubs/linux/fs.h
@@ -1,0 +1,51 @@
+#ifndef _BBG_TEST_LINUX_FS_H_
+#define _BBG_TEST_LINUX_FS_H_
+
+#include <stddef.h>
+
+#define _IOC_NRBITS		8
+#define _IOC_TYPEBITS		8
+#define _IOC_SIZEBITS		14
+#define _IOC_NRSHIFT		0
+#define _IOC_TYPESHIFT		(_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_SIZESHIFT		(_IOC_TYPESHIFT + _IOC_TYPEBITS)
+#define _IOC_DIRSHIFT		(_IOC_SIZESHIFT + _IOC_SIZEBITS)
+#define _IOC_READ		2U
+#define _IOC(dir, type, nr, size) \
+	(((unsigned int)(dir) << _IOC_DIRSHIFT) | \
+	 ((unsigned int)(type) << _IOC_TYPESHIFT) | \
+	 ((unsigned int)(nr) << _IOC_NRSHIFT) | \
+	 ((unsigned int)(size) << _IOC_SIZESHIFT))
+#define _IOR(type, nr, data_type)	_IOC(_IOC_READ, (type), (nr), \
+					     sizeof(data_type))
+
+#ifndef BBG_TEST_NATIVE_IOCTL_TYPE
+#define BBG_TEST_NATIVE_IOCTL_TYPE	size_t
+#endif
+
+#define BLKROSET		0xBB010001u
+#define BLKROGET		0xBB010002u
+#define BLKGETSIZE		0xBB010003u
+#define BLKRAGET		0xBB010004u
+#define BLKFRAGET		0xBB010005u
+#define BLKSECTGET		0xBB010006u
+#define BLKSSZGET		0xBB010007u
+#define BLKPG			0xBB010008u
+#define BLKBSZGET		_IOR(0x12, 112, BBG_TEST_NATIVE_IOCTL_TYPE)
+#define BLKGETSIZE64		_IOR(0x12, 114, BBG_TEST_NATIVE_IOCTL_TYPE)
+#define BLKDISCARD		0xBB01000Bu
+#define BLKIOMIN		0xBB01000Cu
+#define BLKIOOPT		0xBB01000Du
+#define BLKALIGNOFF		0xBB01000Eu
+#define BLKPBSZGET		0xBB01000Fu
+#define BLKDISCARDZEROES	0xBB010010u
+#define BLKSECDISCARD		0xBB010011u
+#define BLKROTATIONAL		0xBB010012u
+#define BLKZEROOUT		0xBB010013u
+#define BLKGETDISKSEQ		0xBB010014u
+
+#define SG_IO			0xBB010015u
+#define MMC_IOC_CMD		0xBB010016u
+#define NVME_IOCTL_IO_CMD	0xBB010017u
+
+#endif

--- a/tests/policy_stubs/linux/hdreg.h
+++ b/tests/policy_stubs/linux/hdreg.h
@@ -1,0 +1,7 @@
+#ifndef _BBG_TEST_LINUX_HDREG_H_
+#define _BBG_TEST_LINUX_HDREG_H_
+
+#define HDIO_GETGEO		0xBB010018u
+#define HDIO_DRIVE_CMD		0xBB010019u
+
+#endif

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/bbg-host-tests.XXXXXX")
+partition_test_bin=$tmp_dir/partition-match-test.exe
+blkdev_test_bin=$tmp_dir/blkdev-compat-test.exe
+block_policy_test_bin=$tmp_dir/block-policy-test.exe
+block_policy_compat32_test_bin=$tmp_dir/block-policy-compat32-test.exe
+blkdev_legacy_test_bin=$tmp_dir/blkdev-compat-legacy-test.exe
+
+cleanup()
+{
+	rm -rf "$tmp_dir"
+}
+
+cleanup_and_exit()
+{
+	status=$1
+	trap - 0 HUP INT TERM
+	cleanup
+	exit "$status"
+}
+
+run_cc()
+(
+	set -f
+	# These variables follow make-style whitespace-delimited word lists.
+	${CC:-cc} ${CPPFLAGS:-} ${CFLAGS:-} "$@"
+)
+
+trap cleanup 0
+trap 'cleanup_and_exit 129' HUP
+trap 'cleanup_and_exit 130' INT
+trap 'cleanup_and_exit 143' TERM
+
+sh "$repo_dir/tests/detect-block-api-test.sh"
+sh "$repo_dir/tests/detect-lsm-api-test.sh"
+echo "PASS LSM API detector"
+sh "$repo_dir/tests/baseband-guard-source-test.sh"
+
+run_cc -DBBG_HOST_TEST -std=c11 -Wall -Wextra -Werror \
+	-I"$repo_dir" \
+	"$repo_dir/tests/partition_match_test.c" \
+	"$repo_dir/partition_match.c" \
+	-o "$partition_test_bin"
+"$partition_test_bin"
+echo "PASS partition matcher"
+
+run_cc -std=c11 -Wall -Wextra -Werror \
+	-I"$repo_dir/tests/compat_stubs" -I"$repo_dir" \
+	"$repo_dir/tests/blkdev_compat_test.c" \
+	-o "$blkdev_test_bin"
+"$blkdev_test_bin"
+echo "PASS block device compatibility"
+
+run_cc -DBBG_HOST_TEST -std=c11 -Wall -Wextra -Werror \
+	-I"$repo_dir/tests/policy_stubs" -I"$repo_dir" \
+	"$repo_dir/tests/block_policy_test.c" \
+	"$repo_dir/block_policy.c" \
+	-o "$block_policy_test_bin"
+"$block_policy_test_bin"
+echo "PASS block access policy"
+
+run_cc -DBBG_HOST_TEST -DBBG_TEST_NATIVE_IOCTL_TYPE=int \
+	-std=c11 -Wall -Wextra -Werror \
+	-I"$repo_dir/tests/policy_stubs" -I"$repo_dir" \
+	"$repo_dir/tests/block_policy_test.c" \
+	"$repo_dir/block_policy.c" \
+	-o "$block_policy_compat32_test_bin"
+"$block_policy_compat32_test_bin"
+echo "PASS block access policy with 32-bit native ioctl aliases"
+
+run_cc -std=c11 -Wall -Wextra -Werror \
+	-I"$repo_dir/tests/compat_stubs" -I"$repo_dir" \
+	"$repo_dir/tests/blkdev_compat_legacy_test.c" \
+	-o "$blkdev_legacy_test_bin"
+"$blkdev_legacy_test_bin"
+echo "PASS legacy block device compatibility"


### PR DESCRIPTION
## 概要

这是已合并 #85 的独立后续修复：在保留 disk API 重构的基础上，补齐不同 Android/Linux 内核的 API 兼容性，并加固 BBG-untrusted 进程对块设备的写入与命令通道。

## 根因与影响

#85 将旧的 `/dev/block/by-name` 检查切换到 disk API，但不同内核树提供的 block/LSM API 组合并不完全由版本号决定；同时，永久缓存 `dev_t` 以及只在部分写入路径执行检查，会在设备号复用、状态变化或 ioctl/io_uring 旁路时留下策略不一致。

本 PR 改为按实际 API 能力探测，并把块设备访问策略统一覆盖到 open、write、ioctl、compat ioctl 与 `uring_cmd`。

## 主要改动

### #85 后续兼容修复

- 由版本号判断改为检测内核实际提供的 API。
- 同时支持 legacy `get_gendisk()` / `disk_get_part()` 与 modern `bd_meta_info` / `blkdev_get_no_open()`。
- 兼容带或不带 `autoload` 参数的 `blkdev_get_no_open()`。
- 配对处理 block device / gendisk 引用。
- 按实际 LSM hook 和 `io_uring_cmd` 定义选择兼容头文件。
- 提取并测试 A/B slot 分区名匹配逻辑。

### 块设备访问加固

- 删除永久 `dev_t` allow cache；zram 与 allowlist 分区每次访问重新解析。
- `file_open`：BBG-untrusted 进程以可写模式打开受保护块设备时拒绝。
- `file_permission`：实际写权限检查时再次执行策略。
- `ioctl`：
  - 保留只读查询；
  - `BLKDISCARD`、`BLKSECDISCARD`、`BLKZEROOUT` 仅允许 allowlist 设备；
  - `SG_IO`、MMC/NVMe passthrough、未知命令及其他非查询命令默认拒绝。
- compat ioctl：进入统一策略前规范化 32-bit `BLKBSZGET` 与 `BLKGETSIZE64`。
- `uring_cmd`：内核支持对应 LSM hook 且启用 `CONFIG_IO_URING` 时注册检查；BBG-untrusted 对块设备提交 `URING_CMD` 时拒绝。
- 保留并统一 `inode_setattr` 保护逻辑。

### deny 日志

- 调用 `get_cmdline()` 前初始化缓冲区。
- 仅在成功取得命令行后输出 `argv`。
- 使用统一的 `DEFINE_RATELIMIT_STATE` 限制详细 deny 日志。

## 验证

本地 host tests 已通过：

```sh
CC=tcc sh tests/run-tests.sh
```

测试覆盖 legacy/modern/autoload/不完整 block API 组合、引用配对、A/B slot、open/write/ioctl/compat/uring 策略、32-bit ioctl alias、LSM hook/头文件探测和 deny 日志源码不变量。

GitHub Actions 新增 `host-tests`，并让它作为 kernel build job 的前置检查。构建矩阵覆盖 Linux 5.10、5.15、6.1、6.6、6.12 和 6.18。

## 合并前重点运行时审查

> [!IMPORTANT]
> `SQPOLL` 会保存 ring 创建时的 credentials。若 trusted 进程先创建 SQPOLL ring，随后 `exec` 成为 BBG-untrusted 进程，`bb_uring_cmd()` 可能仍观察到旧的 trusted credentials。
>
> 当前 host tests 验证了静态策略和 hook 接线，但这一 credentials 边界仍需真实设备验证。

请在合并前重点验证：

- [ ] trusted 进程创建 SQPOLL ring
- [ ] 同一进程 `exec` 为 BBG-untrusted 程序
- [ ] 通过原 ring 向块设备提交 `URING_CMD`
- [ ] 操作返回 `-EPERM`
- [ ] deny 日志受到限速
- [ ] 普通 untrusted `URING_CMD` 同样返回 `-EPERM`
- [ ] trusted 正常路径保持可用
